### PR TITLE
small fix for south korean numbers

### DIFF
--- a/lib/phony/countries/south_korea.rb
+++ b/lib/phony/countries/south_korea.rb
@@ -9,7 +9,7 @@ service = %w{ 30 50 60 70 80 100 101 105 106 107 108 109 111 112 113 114 115 116
 mobile  = ('10'..'19').to_a
 
 Phony.define do
-  country '82', one_of(*service)              >> split(3,3) |
-                one_of(*mobile)               >> split(4,4) |
+  country '82', one_of(*mobile)               >> split(4,4) |
+                one_of(*service)              >> split(3,3) |
                 one_of('2', :max_length => 2) >> split(4,4) # Seoul
 end

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -162,6 +162,7 @@ describe 'country descriptions' do
       Phony.split('82212345678').should == ['82', '2', '1234', '5678']   # Seoul
       Phony.split('825112345678').should == ['82', '51', '1234', '5678'] # Busan
       Phony.split('821027975588').should == ['82', '10', '2797', '5588'] # mobile
+      Phony.split('821087971234').should == ['82', '10', '8797', '1234'] # mobile
     end
     it 'handles thai numbers' do
       Phony.split('6621231234').should == ['66', '2', '123', '1234'] # Bangkok


### PR DESCRIPTION
fixes the case where the mobile prefix combined with the first digit of the mobile number causes the number to be identified as a 'service' number. for example, 821087971234 was being identified as 82 108 797 123 (a service number with a 108 prefix) rather than 82 10 8797 1234 (a mobile number with a 10 prefix)
