### PR TITLE
Improvements to the brazilian phone format

### DIFF
--- a/lib/phony.rb
+++ b/lib/phony.rb
@@ -21,6 +21,7 @@ require File.expand_path '../phony/dsl', __FILE__
 # The ones that need more space to define.
 #
 require File.expand_path '../phony/countries/austria', __FILE__
+require File.expand_path '../phony/countries/brazil', __FILE__
 require File.expand_path '../phony/countries/china', __FILE__
 require File.expand_path '../phony/countries/germany', __FILE__
 require File.expand_path '../phony/countries/ireland', __FILE__
@@ -41,7 +42,7 @@ module Phony
   # Phony uses a single country codes instance.
   #
   @codes      = CountryCodes.instance
-  @validators = Validators.instance 
+  @validators = Validators.instance
 
   class << self
 
@@ -80,7 +81,7 @@ module Phony
     end
     alias formatted  format
     alias formatted! format!
-    
+
     # Makes a plausibility check.
     #
     # If it returns false, it is not plausible.

--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -159,11 +159,7 @@ Phony.define do
 
   # Brazil (Federative Republic of).
   # http://en.wikipedia.org/wiki/Telephone_numbers_in_Brazil
-  #
-  brazilian_service = /^(1(00|28|9[0-4789]))\d+$/
-  country '55',
-          match(brazilian_service) >> split(3,3) | # Service.
-          fixed(2) >> split(4,4)                   # NDCs
+  # country '55' # Brazil, see special file.
 
   # Chile.
   #
@@ -304,7 +300,7 @@ Phony.define do
   country '250',
 					one_of('25') 						>> split(7) | # Geographic, fixed
 					match(/^(7[238])/)			>> split(7)	| # Non-geographic, mobile
-					one_of('06') 						>> split(6)	  # Satellite					
+					one_of('06') 						>> split(6)	  # Satellite
 
   country '251', todo # Ethiopia
   country '252', todo # Somali Democratic Republic

--- a/lib/phony/countries/brazil.rb
+++ b/lib/phony/countries/brazil.rb
@@ -1,0 +1,101 @@
+# Brazilian phone numbers.
+#
+# http://www.anatel.gov.br/hotsites/CodigosNacionaisLocalidade/TelefoneCelular-CodigosDeArea.htm
+#
+# Note: São Paulo recently added an extra 9 digit to all mobile phones in the 11 area code
+#
+ndcs = [
+ '11', #Sao Paulo
+ '12', #Sao Paulo
+ '13', #Sao Paulo
+ '14', #Sao Paulo
+ '15', #Sao Paulo
+ '16', #Sao Paulo
+ '17', #Sao Paulo
+ '18', #Sao Paulo
+ '19', #Sao Paulo
+
+ '21', #Rio de Janeiro
+ '22', #Rio de Janeiro
+
+ '24', #Rio de Janeiro
+
+
+ '27', #Espírito Santo
+ '28', #Espírito Santo
+
+
+ '31', #Minas Gerais
+ '32', #Minas Gerais
+ '33', #Minas Gerais
+ '34', #Minas Gerais
+ '35', #Minas Gerais
+ '36', #Minas Gerais
+ '37', #Minas Gerais
+ '38', #Minas Gerais
+
+
+ '41', #Paraná
+ '42', #Paraná
+ '43', #Paraná
+ '44', #Paraná
+ '45', #Paraná
+ '46', #Paraná
+ '47', #Santa Catarina
+ '48', #Santa Catarina
+ '49', #Santa Catarina
+
+ '51', #Rio Grande do Sul
+ '52', #Rio Grande do Sul
+ '53', #Rio Grande do Sul
+ '54', #Rio Grande do Sul
+ '55', #Rio Grande do Sul
+
+ '61', #Distrito Federal
+ '62', #Goiânia
+ '63', #Tocantins
+ '64', #Goiânia
+ '65', #Mato Grosso
+ '66', #Mato Grosso
+ '67', #Mato Grosso do Sul
+ '68', #Acre
+ '69', #Rondônia
+
+ '71', #Bahia
+ '72', #Bahia
+ '73', #Bahia
+ '74', #Bahia
+ '75', #Bahia
+
+ '77', #Bahia
+ '78', #Bahia
+ '79', #Sergipe
+
+ '81', #Pernambuco
+ '82', #Alagoas
+ '83', #Paraíba
+ '84', #Rio Grande do Norte
+ '85', #Ceará
+ '86', #Piauí
+ '87', #Pernambuco
+ '88', #Ceará
+ '89', #Piauí
+
+ '91', #Pará
+ '92', #Amazonas
+ '93', #Pará
+ '94', #Pará
+ '95', #Roraima
+ '96', #Amapá
+ '97', #Amazonas
+ '98', #Maranhão
+ '99', #Maranhão
+
+]
+service = %w{ 100, 128, 190 191 192 193 194 197 198 199 } # State specific numbers were not added. See http://www.brasil.gov.br/navegue_por/aplicativos/agenda
+
+Phony.define do
+  country '55', one_of(service) >> split(3,3) |
+                one_of(ndcs)    >> split(4,4) |
+                fixed(3)        >> split(4,4)
+end

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -49,6 +49,7 @@ describe 'country descriptions' do
     end
     describe 'Brazil' do
       it_splits '551112341234', ['55', '11', '1234', '1234']
+      it_splits '5511981231234', ['55', '11', '9812', '31234'] # São Paulo's 9 digits mobile
     end
     describe 'Cambodia' do
       it_splits '85512236142', ["855", "12", "236", "142"]   # mobile (Mobitel)


### PR DESCRIPTION
I have moved the Brazil format to a file of its own, adding every state that has area codes to it, like the rest of the countries.

Please note that there is a new special case in São Paulo, the (11) area code now accepts 9 digit mobile numbers.

I'm not sure if the definition is correct, but it didn't break any tests.

Let me know if there is anything I can do to fix it, I'm sending this pull request after seeing phony on the 24pullrequests.com site.

Merry christmas!

FK
