### PR TITLE
More accurate Khmer numbers

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -110,7 +110,7 @@ Phony.define do
   #
   country '45',
           none >> split(2,2,2,2..2)
-          
+
   # country '46' # Sweden, see special file.
 
   # Norway.
@@ -853,6 +853,7 @@ Phony.define do
   # Cambodia (Kingdom of)
   # http://en.wikipedia.org/wiki/Telephone_numbers_in_Cambodia
   country '855',
+          match(/^(1\d{1})/) >> split(3, 3) |
           fixed(2) >> matched_split(/^\d{6}$/ => [3,3], /^\d{7}$/ => [3,4])
 
   # Lao People's Democratic Republic http://www.wtng.info/wtng-856-la.html, https://www.numberingplans.com

--- a/spec/lib/phony/validations_spec.rb
+++ b/spec/lib/phony/validations_spec.rb
@@ -325,10 +325,22 @@ describe 'validations' do
       it_is_correct_for 'Brunei Darussalam', :samples => '+673 5 523 876'
       it_is_correct_for 'Burkina Faso', :samples => '+226  1476 2312'
       it_is_correct_for 'Burundi', :samples => '+257  1234 5678'
-      it_is_correct_for "Cambodia", :samples => [["+855 12 236 142",
-                                                "+855 97 710 0872"],
-                                                ["+855 234 601 183",
-                                                "855 33 123 456"]]
+
+      it 'is correct for Cambodia' do
+        # 7 digit identifiers
+        Phony.plausible?("+855965787807").should be_true    # Smart
+        Phony.plausible?("+855312067777").should be_true    # Beeline
+        Phony.plausible?("+855383001801").should be_true    # CooTel
+        Phony.plausible?("+855973001801").should be_true    # Metfone
+        Phony.plausible?("+855883001801").should be_true    # Metfone
+        Phony.plausible?("+85510234567").should be_true     # Smart
+        Phony.plausible?("+85511234564").should be_true     # Mobitel (former Mfone)
+        Phony.plausible?("+855 12 236 142").should be_true  # Mobitel
+        Phony.plausible?("+855 234 601 183").should be_true # Long fixed line (Phnom Penh)
+        Phony.plausible?("855 33 123 456").should be_true   # Regular fixed line (Kampot)
+        Phony.plausible?("+855102345678").should be_false   # Too many digits for a 01 prefix
+      end
+
       it_is_correct_for 'Cameroon', :samples => '+237  7372 8186'
       it_is_correct_for 'Cape Verde', :samples => '+238  642 3843'
       it_is_correct_for 'Central African Republic', :samples => '+236  1234 5678'


### PR DESCRIPTION
9 digit local numbers with the prefix 01 are invalid in Cambodia. See http://en.wikipedia.org/wiki/Telephone_numbers_in_Cambodia#Mobile_Phones
