### PR TITLE
Make Phony recognize special Brazilian numbers

### DIFF
--- a/lib/phony/countries/brazil.rb
+++ b/lib/phony/countries/brazil.rb
@@ -95,9 +95,14 @@ ndcs = [
 ]
 service = %w{ 100, 128, 190 191 192 193 194 197 198 199 } # State specific numbers were not added. See http://www.brasil.gov.br/navegue_por/aplicativos/agenda
 
+special_numbers_3_4 = %w{ 0800 }
+special_numbers_4 = %w{ 3003 4004 4020 }
+
 Phony.define do
   country '55', match(/^(11|12|13|14|15|16|17|18|19|21|22|24|27|28)9\d+$/) >> split(5,4) |
-                one_of(service)     >> split(3,3) |
-                one_of(ndcs)        >> split(4,4) |
-                fixed(3)            >> split(4,4)
+                one_of(special_numbers_3_4)  >> split(3,4) |
+                one_of(special_numbers_4)    >> split(4) |
+                one_of(service)              >> split(3,3) |
+                one_of(ndcs)                 >> split(4,4) |
+                fixed(3)                     >> split(4,4)
 end

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -111,6 +111,13 @@ describe 'country descriptions' do
           it_splits "55#{state_code}993051123", ['55', state_code, '99305', '1123']
         end
       end
+
+      context "special numbers" do
+        it_splits '5508002221234', ['55', '0800', '222', '1234']
+        it_splits '5530032221', ['55', '3003', '2221']
+        it_splits '5540209999', ['55', '4020', '9999']
+        it_splits '5540048999', ['55', '4004', '8999']
+      end
     end
     describe 'Cambodia' do
       it_splits '85512236142', ["855", "12", "236", "142"]   # mobile (Mobitel)


### PR DESCRIPTION
This PR let the phony to recognize numbers like:

0800 312 000
3003 1222
4004 0001

This PR include https://github.com/floere/phony/pull/120

It is a separated pull request, because the #120 very needed, but I do not know if these special numbers are part of the standard E164
