### PR TITLE
Attempt to fix parsing issue for 663 and 676 prefixes

### DIFF
--- a/lib/phony/countries/austria.rb
+++ b/lib/phony/countries/austria.rb
@@ -83,5 +83,6 @@ Phony.define do
                 one_of(corporate) >> split(5..5) |
                 one_of(ndcs)      >> split(6..6) |
                 one_of(mobile)    >> split(7..7) |
+                one_of('663')     >> split(6..6) |
                 fixed(4)          >> split(7..7)
 end

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -114,6 +114,17 @@ describe 'plausibility' do
     end
 
     context 'specific countries' do
+      it "is correct for Austria" do
+        Phony.plausible?('+43 501 12345').should be_true
+        Phony.plausible?('+43 501 1234').should be_false # too short
+        Phony.plausible?('+43 501 123456').should be_false # too long
+        Phony.plausible?('+43 800 123456789').should be_true
+
+        # Mobile
+        Phony.plausible?('+43 676 0000000').should be_true
+        # 663 mobile numbers have 6 digits
+        Phony.plausible?('+43 663 000000').should be_true
+      end
 
       # TODO: more needs to be done here
       #
@@ -233,13 +244,6 @@ describe 'plausibility' do
         Phony.plausible?('+7 960 301 23 45').should be_true
         Phony.plausible?('+7 800 2000 60').should be_false # too short
         Phony.plausible?('796030123451').should be_false # too long
-      end
-
-      it "is correct for Austria" do
-        Phony.plausible?('+43 501 12345').should be_true
-        Phony.plausible?('+43 501 1234').should be_false # too short
-        Phony.plausible?('+43 501 123456').should be_false # too long
-        Phony.plausible?('+43 800 123456789').should be_true
       end
 
       it "is correct for Azerbaijan" do


### PR DESCRIPTION
References:
- +43 644 1425088 -> http://www.moses-mendelssohn-synagoge.com/index.php/en/sponsor
- +43 676 0000000 -> http://iteh.at/en/contact/
- +43 663 700067  -> http://www.yelp.com/search?cflt=carrental&find_loc=Gmunden%2C+Ober%C3%B6sterreich

However, specs are not passing. This is strange.

  1) plausibility plausible? specific countries is correct for Austria
     Failure/Error: Phony.plausible?('+43 676 0000000').should be_true
       expected: true value
            got: false
     # ./spec/functional/plausibility_spec.rb:124:in `block (4 levels) in <top (required)>'

I wonder if this is because the library is matching `67` and stopping there. This is something I noticed before. Shouldn't  the library continue if the match doesn't match?

I mean, if you set a rule for `123` and then a fallback, there should be a way I could say "move next" if doesn't match, or just it does not match so stop here.

In fact, in this case I'd really love the parser to try to fallback to all the rules in the mobile array, before stopping.

Any hint is appreciated.
