### PR TITLE
Add docs badge to README

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,5 +1,6 @@
 "!{float:right}https://secure.travis-ci.org/floere/phony.png!":http://travis-ci.org/floere/phony
 "!https://codeclimate.com/github/floere/phony.png!":https://codeclimate.com/github/floere/phony
+!http://inch-pages.github.io/github/floere/phony.png!:http://inch-pages.github.io/github/floere/phony
 
 h1. Phony
 


### PR DESCRIPTION
Hi Florian,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/floere/phony.png)](http://inch-pages.github.io/github/floere/phony) (and hopefully inspire them to write good docs as well!)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for Phony is http://inch-pages.github.io/github/floere/phony/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard), [Pry](https://github.com/pry/pry), and [Libnotify](https://github.com/splattael/libnotify).

What do you think?
