### PR TITLE
Remove leading 0 from Spain national format

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -81,7 +81,7 @@ Phony.define do
   # Spain.
   #
   country '34',
-          fixed(2) >> split(3,4)
+          fixed(2, :zero => false) >> split(3,4)
 
   # Hungary.
   #

--- a/spec/lib/phony/country_codes_spec.rb
+++ b/spec/lib/phony/country_codes_spec.rb
@@ -69,6 +69,9 @@ describe Phony::CountryCodes do
       it 'formats ireland correctly' do
         @countries.formatted("353411231234", :format => :national).should eql '041 123 1234'
       end
+      it 'formats spain correctly' do
+        @countries.formatted("34123456789", :format => :national).should eql '12 345 6789'
+      end
     end
     context 'default' do
       it "should format swiss numbers" do


### PR DESCRIPTION
Spain phone numbers do not have a leading zero in national format.
http://en.wikipedia.org/wiki/Trunk_prefix#Countries_no_longer_using_a_national_trunk_prefix
http://www.wtng.info/wtng-34-es.html

This simple pull request remove the leading zero on format :national.
