### PR TITLE
6 and 8 digit mobile number support for NZ (+64)

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -212,10 +212,10 @@ Phony.define do
   # New Zealand.
   #
   country '64',
-          match(/^(2\d)\d{7}$/) >> split(3,4) | # Mobile
-          match(/^(2\d)\d{6}$/) >> split(3,3) |
-          match(/^(2\d)\d{8}$/) >> split(4,4) |
-          fixed(1) >> split(3,4)                # Rest
+          match(/^(2\d)\d{7}$/) >> split(3,4)   | # Mobile
+          match(/^(2\d)\d{6}$/) >> split(3,3)   |
+          match(/^(2\d)\d{8}$/) >> split(2,3,3) |
+          fixed(1) >> split(3,4)                  # Rest
 
   # Singapore (Republic of).
   #

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -362,7 +362,7 @@ describe 'plausibility' do
         Phony.plausible?('+64 21 123 456').should be_true
         Phony.plausible?('+64 21 123 4567').should be_true
         Phony.plausible?('+64 9 379 1234').should be_true
-        Phony.plausible?('+64 21 1234 5678').should be_true
+        Phony.plausible?('+64 21 12 345 678').should be_true
         Phony.plausible?('+64 21 1234 56789').should be_false # to long
         Phony.plausible?('+64 21 12345').should be_false # to short
       end

--- a/spec/lib/phony_spec.rb
+++ b/spec/lib/phony_spec.rb
@@ -140,7 +140,7 @@ describe Phony do
         Phony.format('64211234567').should eql '+64 21 123 4567'
       end
       it 'should format New Zealand 021 8-digit mobile numbers' do
-        Phony.format('642112345678').should eql '+64 21 1234 5678'
+        Phony.format('642112345678').should eql '+64 21 12 345 678'
       end
       it 'should format New Zealand landline numbers' do
         Phony.format('6493791234').should eql '+64 9 379 1234'


### PR DESCRIPTION
I got a problem.
Mobile number "+642142xxxx" wasn't plausible.

Wiki says that NZ mobile numbers starts with 02 can have from 6 to 8 digit number
http://en.wikipedia.org/wiki/Telephone_numbers_in_New_Zealand

The same here: http://www.tnzi.com/about-us/numbering-plan/
"Mobiles/pagers: 2-digit code plus 6-, 7- or 8-digit numbers"

6-digit format:
http://forums.whirlpool.net.au/archive/1542609
"From a mobile: +64 xx yyy zzz"

I'm not sure about correct 8-digit format, so just set it to xxxx yyyy. I'll ask one guy from NZ about 8-digit phone number format and change it if it will be required.
