### PR TITLE
Update netherlands.rb

### DIFF
--- a/lib/phony/countries/netherlands.rb
+++ b/lib/phony/countries/netherlands.rb
@@ -56,7 +56,7 @@ service3 = [
 Phony.define do
   country '31', 
     one_of(service) >> split(4,3) |
-    one_of(service3) >> split(3,3) |
+    one_of(service3) >> split(4,3) |
     one_of('6')  >> split(2,2,2,2) | # mobile
     one_of(ndcs) >> split(3,4)     | # landline (geographic region)
     fixed(3)     >> split(3,3)       # 3 digit ndc


### PR DESCRIPTION
These service number prefixes are followed by 7 digits (http://en.wikipedia.org/wiki/Premium-rate_telephone_number#Netherlands)
