### PR TITLE
Fix several Austrian numbers

### DIFF
--- a/lib/phony/countries/austria.rb
+++ b/lib/phony/countries/austria.rb
@@ -83,12 +83,12 @@ service = [
 # TODO Add more details.
 #
 Phony.define do
-  country '43', one_of('1')       >> split(4..4) | # Vienna
+  country '43', one_of('1')       >> split(3..12) | # Vienna
                 one_of(service)   >> split(9..9) |
                 one_of(corporate) >> split(5..5) |
                 one_of(ndcs)      >> split(6..6) |
                 one_of('663')     >> split(6..6) | # 6 digit mobile.
-                one_of(mobile)    >> split(7..7) |
+                one_of(mobile)    >> split(4,3..4) |
                 one_of(mobile_2digit) >> split(7..7) | # Separate as mobile contains 676 - 67 violates the prefix rule.
                 fixed(4)          >> split(7..7)
 end

--- a/lib/phony/country_codes.rb
+++ b/lib/phony/country_codes.rb
@@ -166,18 +166,18 @@ module Phony
     
     def plausible? number, hints = {}
       normalized = clean number
-      
+
       # False if it fails the basic check.
       #
       return false unless (4..15) === normalized.size
       
       country, cc, rest = split_cc normalized
-      
+
       # Country code plausible?
       #
       cc_needed = hints[:cc]
       return false if cc_needed && !(cc_needed === cc)
-      
+
       # Country specific tests.
       #
       country.plausible? rest, hints

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -113,7 +113,13 @@ describe 'plausibility' do
     end
 
     context 'specific countries' do
+      it "" do
+        Phony.plausible?('+43 699 00000000').should be_true
+      end
+
       it "is correct for Austria" do
+        Phony.plausible?('+43 1 000000').should be_true
+        Phony.plausible?('+43 1 0000000').should be_true
         Phony.plausible?('+43 501 12345').should be_true
         Phony.plausible?('+43 501 1234').should be_false # too short
         Phony.plausible?('+43 501 123456').should be_false # too long
@@ -121,6 +127,9 @@ describe 'plausibility' do
 
         # Mobile
         Phony.plausible?('+43 676 0000000').should be_true
+        Phony.plausible?('+43 681 00000000').should be_true
+        Phony.plausible?('+43 688 0000000').should be_true
+        Phony.plausible?('+43 699 00000000').should be_true
         # 663 mobile numbers have 6 digits
         Phony.plausible?('+43 663 000000').should be_true
       end

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -16,13 +16,16 @@ describe 'country descriptions' do
     describe 'Ascension Island' do
       it_splits '2473551', ['247', false, '3551']
     end
+
     describe 'Afghanistan' do
       it_splits '93201234567', ['93', '20', '1234567'] # Kabul
     end
+
     describe 'Algeria' do
       it_splits '213211231234', ['213', '21', '123', '1234'] # Algiers
       it_splits '213331231234', ['213', '33', '123', '1234'] # Batna
     end
+
     describe 'Argentina' do
       it_splits '541112345678', ['54', '11', '1234', '5678']
       it_splits '542911234567', ['54', '291', '123', '4567']
@@ -32,13 +35,18 @@ describe 'country descriptions' do
       it_splits '5492221123456', ['54', '92221', '12', '3456']
       it_splits '548001234567', ['54', '800', '123', '4567']
     end
+
     describe 'Austria' do
-      it_splits '43198110',        ['43', '1', '98110']        # Vienna
-      it_splits '43800123456789',  ['43', '800', '123456789']  # Free
-      it_splits '4366914093902',   ['43', '669', '14093902']   # Mobile
-      it_splits '433161234567891', ['43', '316', '1234567891'] # Graz
-      it_splits '432164123456789', ['43', '2164', '123456789'] # Rohrau
+      it_splits '43198110',        %w( 43 1 98110 )        # Vienna
+      it_splits '4310000000',      %w( 43 1 0000000 )      # Vienna
+      it_splits '43800123456789',  %w( 43 800 123456789 )  # Free
+      it_splits '4368100000000',   %w( 43 681 0000 0000 )  # Mobile
+      it_splits '436880000000',    %w( 43 688 0000 000 )   # Mobile
+      it_splits '4366900000000',   %w( 43 669 0000 0000 )  # Mobile
+      it_splits '433161234567891', %w( 43 316 1234567891 ) # Graz
+      it_splits '432164123456789', %w( 43 2164 123456789 ) # Rohrau
     end
+
     describe 'Australia' do
       it_splits '61512341234', ['61', '5', '1234', '1234'] # Landline
       it_splits '61423123123', ['61', '423', '123', '123'] # Mobile


### PR DESCRIPTION
#### 1 (Vienna) phone numbers can be from 4-13 digits long (including local

code)

Examples:
- +43-1-515180
  http://www.marriott.com/hotels/travel/vieat-vienna-marriott-hotel/
- +43 (1) 727 27-0 http://www.austria-trend.at/hotel-messe-wien/en/
#### 681 and 699 mobile phone numbers are 8 digits long (excluding prefix)

Examples:
- +43 699 1196 1457 http://www.ecomal.com/en/contact/austria/
- Other numbers reported to our DNSimple customer care
#### 688 mobile phone numbers are 7 digits long (excluding prefix)

Examples:
- +43 688 930 7 572 http://www.mhdrinks.com/index.php/ct-menu-item-3
- Other numbers reported to our DNSimple customer care
