### PR TITLE
Add 9 digits to mobile phone with NDC 91 to 99 in Brazil

### DIFF
--- a/lib/phony/countries/brazil.rb
+++ b/lib/phony/countries/brazil.rb
@@ -96,7 +96,7 @@ special_numbers_4 = %w{ 3003 4004 4020 }
 
 Phony.define do
   country '55',
-    match(/^(11|12|13|14|15|16|17|18|19|21|22|24|27|28)9\d{8}$/) >> split(5,4) |
+    match(/^(11|12|13|14|15|16|17|18|19|21|22|24|27|28|91|92|93|94|95|96|97|98|99)9\d{8}$/) >> split(5,4) |
     match(ndcs)                  >> split(4,4) |
     one_of(special_numbers_3_4)  >> split(3,4) |
     one_of(special_numbers_4)    >> split(4) |

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -108,6 +108,7 @@ describe 'country descriptions' do
       it_splits '26776712345', %w(267 7 6712 345)
       it_splits '26781234567', %w(267 8 1234 567)
     end
+
     describe 'Brazil' do
       it_splits '551112341234', ['55', '11', '1234', '1234']
       it_splits '5511981231234', ['55', '11', '98123', '1234'] # São Paulo's 9 digits mobile
@@ -117,7 +118,7 @@ describe 'country descriptions' do
       it_splits '5519991311234', ['55', '19', '99131', '1234'] # Rio de Janeiro's 9 digits mobile
 
       context "special states with 9 in mobile" do
-        %w{ 11 12 13 14 15 16 17 18 19 21 22 24 27 28}.each do |state_code|
+        %w{ 11 12 13 14 15 16 17 18 19 21 22 24 27 28 91 92 93 94 95 96 97 98 99}.each do |state_code|
           it_splits "55#{state_code}993051123", ['55', state_code, '99305', '1123']
         end
       end


### PR DESCRIPTION
It started yesterday and in a couple of months cellphones with 8 digits will be invalid on this area.
Reference (pt-BR): http://www.anatel.gov.br/Portal/exibirPortalNoticias.do?acao=carregaNoticia&codigo=35520
