### PR TITLE
Fixes plausibility? for variable length numbers from the United Kingdom

### DIFF
--- a/lib/phony/countries/united_kingdom.rb
+++ b/lib/phony/countries/united_kingdom.rb
@@ -790,15 +790,15 @@ four_digit_ndc = [
 ]
 
 Phony.define do
-  country '44', 
+  country '44',
     trunk('0') |
-    one_of(mobile_ndc)             >> split(6)   | # 4-6
-    one_of(two_digit_ndc)          >> split(4,4) | # 2-4-4
-    match(/^([58]00)\d{6}$/)       >> split(6)   | # 3-6, Special handling for 500 and 800.
-    one_of(three_digit_ndc)        >> split(3,4) | # 3-3-4
-    match(/^(16977)\d{4}$/)        >> split(4)   | # 5-4, Special handling for 16977.
-    one_of(five_digit_ndc)         >> split(5)   | # 5-5
-    one_of(variable_length_number) >> split(6)   | # 4-6 and 4-5, in 40 areas.
-    one_of(four_digit_ndc)         >> split(6)   | # 4-6
-    fixed(4)                       >> split(6)     # Catchall for undefined numbers.
+    one_of(mobile_ndc)             >> split(6)    | # 4-6
+    one_of(two_digit_ndc)          >> split(4,4)  | # 2-4-4
+    match(/^([58]00)\d{6}$/)       >> split(6)    | # 3-6, Special handling for 500 and 800.
+    one_of(three_digit_ndc)        >> split(3,4)  | # 3-3-4
+    match(/^(16977)\d{4}$/)        >> split(4)    | # 5-4, Special handling for 16977.
+    one_of(five_digit_ndc)         >> split(5)    | # 5-5
+    one_of(variable_length_number) >> split(5..6) | # 4-6 and 4-5, in 40 areas.
+    one_of(four_digit_ndc)         >> split(6)    | # 4-6
+    fixed(4)                       >> split(6)      # Catchall for undefined numbers.
 end

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -815,6 +815,9 @@ describe 'plausibility' do
                                                              '+971 600 641 234',
                                                              '+971 500 641 234',
                                                              '+971 200 641 234']
+
+      it_is_correct_for 'United Kingdom', :samples => ['+44 1827 50111']
+
       it_is_correct_for 'Uruguay (Eastern Republic of)', :samples => ['+598 800 123 45',
                                                                       '+598 2 012 3456',
                                                                       '+598 21 123 456',


### PR DESCRIPTION
Fix for https://github.com/floere/phony/issues/169

Plausibility is now true for a number of the form `+44 1827 XXXXX`. However, plausibility is still false for `+44 1928 XXXXX` (the other number listed in #169), but that is correct according to the data available at http://www.ofcom.org.uk/static/numbering/index.htm which only lists 4+6 for 1928.
