### PR TITLE
dutch 0800 and 0900 numbers can be followed by 4 or 7 digits. http://nl....

### DIFF
--- a/lib/phony/countries/netherlands.rb
+++ b/lib/phony/countries/netherlands.rb
@@ -55,10 +55,11 @@ service3 = [
 
 Phony.define do
   country '31',
-    trunk('0', :normalize => true) |
-    one_of(service) >> split(4,3) |
-    one_of(service3) >> split(4,3) |
-    one_of('6')  >> split(2,2,2,2) | # mobile
-    one_of(ndcs) >> split(3,4)     | # landline (geographic region)
-    fixed(3)     >> split(3,3)       # 3 digit ndc
+    trunk('0', :normalize => true)                |
+    one_of(service)             >> split(4,3)     |
+    match(/\A(800|900)\d{4}\z/) >> split(4)       |
+    one_of(service3)            >> split(4,3)     |
+    one_of('6')                 >> split(2,2,2,2) | # mobile
+    one_of(ndcs)                >> split(3,4)     | # landline (geographic region)
+    fixed(3)                    >> split(3,3)       # 3 digit ndc
 end

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -304,6 +304,7 @@ describe 'plausibility' do
         Phony.plausible?('+31 880 450 24').should be_false
         Phony.plausible?('+31 900 123 4567').should be_true
         Phony.plausible?('+31 900 001 00').should be_false
+        Phony.plausible?('+31 800 6080').should be_true
       end
 
       it 'is correct for Egypt' do


### PR DESCRIPTION
dutch 0800 and 0900 numbers can be followed by 4 or 7 digits.
