### PR TITLE
Adapted Slovenian rule matching based on ITU and Twiki info

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -652,7 +652,15 @@ Phony.define do
 
   # country '385' # Croatia, see special file.
 
-  country '386', trunk('0') | fixed(2) >> split(3, 2, 2) # Slovenia
+  # Slovenia
+  # http://www.itu.int/oth/default.aspx?lang=en&parent=T02020000BE
+  # http://en.wikipedia.org/wiki/Telephone_numbers_in_Slovenia
+  country '386',
+          trunk('0') |
+          one_of('30','31','40','41','51','64','65','66','67','68','69','70','71')  >> split(3,3) | # Mobile
+          one_of('1','2','3','4','5','7')  >> split(3,4) | # Ljubljana, Maribor, Celje, Kranj, Nova Gorica, Novo mesto
+          fixed(3)                         >> split(2,3)   # catchall
+
   country '387', trunk('0') | fixed(2) >> split(3,2,2) # Bosnia and Herzegovina
   country '388', trunk('0') | fixed(2) >> split(3,2,2) # Group of countries, shared code
   country '389', trunk('0') | fixed(2) >> split(3,2,2) # The Former Yugoslav Republic of Macedonia

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -429,6 +429,12 @@ describe 'plausibility' do
         Phony.plausible?('796030123451').should be_false # too long
       end
 
+      it "is correct for Slovenian numbers" do
+        Phony.plausible?('+386 41 123 456').should be_true
+        Phony.plausible?('+386 1 320 1234').should be_true
+        Phony.plausible?('+386 41 123 4567').should be_false
+      end
+
       # TODO: more needs to be done here
       #
       it "is correct for Swiss numbers" do

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -570,6 +570,11 @@ describe 'country descriptions' do
       it { Phony.split('421371234567').should == ['421', '37', '1234567'] } # Nitra / Other
     end
 
+    describe 'Slovenia' do
+      it { Phony.split('38651234567').should == ['386', '51', '234', '567'] }  # Mobile
+      it { Phony.split('38611234567').should == ['386', '1', '123', '4567'] }  # LJUBLJANA
+    end
+
     describe 'Spain' do
       it_splits '34600123456', ['34', '600', '123', '456'] # Mobile
       it_splits '34900123456', ['34', '900', '123', '456'] # Special


### PR DESCRIPTION
Page 1 of the ITU document http://www.itu.int/oth/default.aspx?lang=en&parent=T02020000BE indicates the
possible structures of the National (Significant) Numbers. We used this information, with the focus on
mobile numbers, to fix up the parsing rules. Furthermore, the maximum length of the NSN is 8 digits whic
meant that the previous parsing rule (fixed(2) >> split(3, 2, 2)) would not return the correct plausibility
results for valid numbers.

Added plausibility as well as formatting specs.
