### PR TITLE
Austrian mobile numbers can have 7-10 digits in the subscriber number

### DIFF
--- a/lib/phony/countries/austria.rb
+++ b/lib/phony/countries/austria.rb
@@ -89,7 +89,7 @@ Phony.define do
                 one_of(corporate) >> split(5..5) |
                 one_of(ndcs)      >> split(6..6) |
                 one_of('663')     >> split(6..6) | # 6 digit mobile.
-                one_of(mobile)    >> split(4,3..4) |
+                one_of(mobile)    >> split(4,3..9) |
                 one_of(mobile_2digit) >> split(7..7) | # Separate as mobile contains 676 - 67 violates the prefix rule.
                 fixed(4)          >> split(7..7)
 end

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -148,6 +148,11 @@ describe 'plausibility' do
         Phony.plausible?('+43 699 00000000').should be_true
         # 663 mobile numbers have 6 digits
         Phony.plausible?('+43 663 000000').should be_true
+        # mobile numbers can have from 7 to 10 digits in the subscriber number
+        Phony.plausible?('+43 664 1234 567').should be_true
+        Phony.plausible?('+43 664 1234 5678').should be_true
+        Phony.plausible?('+43 664 1234 56789').should be_true
+        Phony.plausible?('+43 664 1234 567890').should be_true
       end
 
       it "is correct for Belgian numbers" do

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -45,6 +45,12 @@ describe 'country descriptions' do
       it_splits '4366900000000',   %w( 43 669 0000 0000 )  # Mobile
       it_splits '433161234567891', %w( 43 316 1234567891 ) # Graz
       it_splits '432164123456789', %w( 43 2164 123456789 ) # Rohrau
+
+      # mobile numbers can have from 7 to 10 digits in the subscriber number
+      it_splits '436641234567',    %w( 43 664 1234 567 )
+      it_splits '4366412345678',   %w( 43 664 1234 5678 )
+      it_splits '43664123456789',  %w( 43 664 1234 56789 )
+      it_splits '436641234567890', %w( 43 664 1234 567890 )
     end
 
     describe 'Australia' do


### PR DESCRIPTION
As listed in the table on page 17 of the Austrian ITU document https://www.rtr.at/en/tk/E129/2312_Austrian_Numbering_Plan_2011-03-30.pdf
a mobile number can be between 7 and 10 digits in the subscriber number. This is also something we noticed with some of our customers
as well.
