### PR TITLE
Split Italian mobile numbers into 3,4 chunks but allow the subscriber le...

### DIFF
--- a/lib/phony/countries/italy.rb
+++ b/lib/phony/countries/italy.rb
@@ -112,7 +112,7 @@ service = [ # Not exhaustive.
 Phony.define do
   country '39', trunk('0', :normalize => false) |
                 one_of(*service)     >> split(3,3) |
-                one_of(*mobile)      >> split(3,4) |
+                one_of(*mobile)      >> split(3,4,-1..1) |
                 one_of(*ndcs_2digit) >> split(4,4) |
                 one_of(*ndcs_3digit) >> split(6..7) |
                 one_of(*ndcs_4digit) >> split(3,3)

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -384,8 +384,12 @@ describe 'plausibility' do
         Phony.plausible?('+39 0471 123 456').should be_true
 
         # Mobile
-        Phony.plausible?('+39 335 123 4567').should be_true
         Phony.plausible?('+39 335 123').should be_false
+        Phony.plausible?('+39 335 123 45').should be_false
+        Phony.plausible?('+39 335 123 456').should be_true
+        Phony.plausible?('+39 335 123 4567').should be_true
+        Phony.plausible?('+39 335 123 45678').should be_true
+        Phony.plausible?('+39 335 123 456789').should be_false
       end
 
       it 'is correct for Malaysia' do

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -351,7 +351,9 @@ describe 'country descriptions' do
       it_splits '9701700123123', ['970', '1', '700', '123', '123']  # Cable Phone Services
     end
     describe 'Italy' do
-      it_splits '3934869528',   ['39', '348', '695', '28']   # Mobile
+      it_splits '39348695281',  ['39', '348', '695', '281']        # Mobile (6-digit subscriber no. - rare, but still used)
+      it_splits '393486952812', ['39', '348', '695', '2812']       # Mobile (7-digit subscriber no. - common)
+      it_splits '3934869528123',['39', '348', '695', '2812', '3']  # Mobile (8-digit subscriber no - new)
       it_splits '393357210488', ['39', '335', '721', '0488'] # Mobile
       it_splits '393248644272', ['39', '324', '864', '4272'] # Mobile
       it_splits '390612341234', ['39', '06', '1234', '1234'] # Roma


### PR DESCRIPTION
...ngth to range from 6-8 digits.

The standard length of mobile numbers is 10 digits (3 + t subscriber), but as outlined here
http://en.wikipedia.org/wiki/Telephone_numbers_in_Italy#Mobile_telephones, there are 6-digit subscriber numbers
as well as 11. The ITU document for Italy, http://www.itu.int/dms_pub/itu-t/oth/02/02/T020200006B0001PDFE.pdf,
also touches on this on page 14 listing that the minimum number of digits for a mobile number is 9 (here they refer
to ndc + subcriber). Moreover, we also have users with these 9-digit numbers, which is how we actually stumbled
across this problem in the first place.
