### PR TITLE
Extended Estonia number parsing to accept mobile numbers in the 5xx rang...

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -612,8 +612,8 @@ Phony.define do
   # Estonia
   #
   country '372',
-          match(/^(5\d\d\d)\d+$/)          >> split(4) | # Mobile
-          match(/^((?:70|8[12])\d\d)\d+$/) >> split(4) | # Mobile
+          match(/^(5\d\d\d)\d+$/)          >> split(3..4) | # Mobile
+          match(/^((?:70|8[12])\d\d)\d+$/) >> split(4)    | # Mobile
           fixed(3)                         >> split(4)   # 3-digit NDCs
 
   # country '373' # Moldova, see special file

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -304,6 +304,22 @@ describe 'plausibility' do
         Phony.plausible?('+45 44 55 22 33').should be_true
       end
 
+      it "is correct for Estonia" do
+        # the 5xxxx mobile numbers can be 7 or 8 digits (ndc + subscriber) long
+        Phony.plausible?('+372 532 12345').should be_true
+        Phony.plausible?('+372 532 1234').should be_true
+        Phony.plausible?('+372 532 123').should be_false
+        Phony.plausible?('+372 532 123456').should be_false
+
+        # the 81x/82x are only 8 digits
+        Phony.plausible?('+372 822 12345').should be_true
+        Phony.plausible?('+372 812 12345').should be_true
+        Phony.plausible?('+372 822 1234').should be_false
+        Phony.plausible?('+372 812 1234').should be_false
+        Phony.plausible?('+372 822 123').should be_false
+        Phony.plausible?('+372 822 123456').should be_false
+      end
+
       it 'is correct for Netherlands' do
         Phony.plausible?('+31 6 12 34 56 78').should be_true
         Phony.plausible?('+31 6 12 34 56 7').should be_false

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -188,7 +188,8 @@ describe 'country descriptions' do
       it_splits '3728001234',  ['372', '800', '1234']   # Freephone
       it_splits '37281231234', ['372', '8123', '1234']  # Mobile
       it_splits '37282231234', ['372', '8223', '1234']  # Mobile
-      it_splits '37283212345', ['372', '832', '12345']  # Mobile
+      it_splits '37252212345', ['372', '5221', '2345']  # Mobile
+      it_splits '3725221234', ['372',  '5221', '234']  # Mobile
       it_splits '37270121234', ['372', '7012', '1234']  # Premium
     end
     describe 'Finland' do


### PR DESCRIPTION
...e to have a length of 7 or 8.

The ITU document on Estonia, http://www.itu.int/dms_pub/itu-t/oth/02/02/T02020000430001PDFE.pdf, indicates on
page 4 that the number range 50-59 contains 8 digits, however, if you look at http://en.wikipedia.org/wiki/Telephone_numbers_in_Estonia
and https://www.numberingplans.com/?page=plans&sub=phonenr&alpha_2_input=EE&current_page=69, it appears that this is not
entirely correct. the 5xx range can be either 7 or 8 digits long and this is something that we are also seeing with some of our
clients.

Now to be fair to the ITU document, as an additional remark, it states the following.

"Differences in § 19 section 1 of the “Estonian Numbering Plan” Regulation, Mobile telephone service"

I am not sure what other document this is referring to as the § 19 section 1 is not part of the one pointed to by the aforementioned link.
In either case, given the other sources of information along with some of our clients, it seems that the 7/8 digit is something that
needs to be taken into account.
