### PR TITLE
Extended parsing for Mexican numbers for dialing cell phones from abroad

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -158,10 +158,14 @@ Phony.define do
 
   # Mexico.
   #
+  # http://en.wikipedia.org/wiki/Telephone_numbers_in_Mexico
+  # http://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers#Mexico
   country '52',
-          match(/^(0\d{2})\d+$/)   >> split(2,2,2,2) |
-          match(/^(33|55|81)\d+$/) >> split(2,2,2,2) |
-          match(/^(\d{3})\d+$/)    >> split(3,2,2)     # catchall.
+          match(/^(0\d{1,2})\d{10}$/)   >> split(3,3,4)   | # prefixed numbers from within Mexico (e.g. 045 + 10 digits or 02 + 10 digits)
+          match(/^(1)(33|55|81)\d{8}$/) >> split(2,4,4)   | # Mexico D.F, Guadalajara, Monterrey cell phone from abroad (e.g. 52 1 55 xxxx xxxx)
+          match(/^(33|55|81)\d{8}$/)    >> split(4,4)     | # Mexico D.F, Guadalajara, Monterrey from within Mexico
+          match(/^(1)(\d{3})\d{7}$/)    >> split(3,3,4)   | # cell phone from abroad
+          match(/^(\d{3})\d{7}$/)       >> split(3,4)       # catchall.
 
   # Cuba.
   #

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -426,6 +426,16 @@ describe 'plausibility' do
         Phony.plausible?('+60 14 1234 12345').should be_false  # too long
       end
 
+      it 'is correct for Mexico' do
+        Phony.plausible?('+52 1 55 1212 1212').should be_true
+        Phony.plausible?('+52 55 1212 1212').should be_true
+        Phony.plausible?('+52 664 123 1212').should be_true
+        Phony.plausible?('+52 1 664 123 1212').should be_true
+        Phony.plausible?('+52 044 664 123 1212').should be_true
+        Phony.plausible?('+52 1 55 1212 1212 3').should be_false  # too long
+        Phony.plausible?('+52 55 1212 121').should be_false     # too short
+      end
+
       it "is correct for Netherlands Antilles" do
         Phony.plausible?('+599 1234567').should be_true
         Phony.plausible?('+599 123456').should be_false # too short

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -426,8 +426,11 @@ describe 'country descriptions' do
       it_splits '35651231234', ['356', '5123', '1234'] # Voice Mail
     end
     describe 'Mexico' do
-      it_splits '525512121212', ['52', '55', '12', '12', '12', '12'] # Mexico City
-      it_splits '526641231212', ['52', '664', '123', '12', '12']     # Tijuana
+      it_splits '525512121212',  ['52', '55', '1212', '1212']         # Mexico City
+      it_splits '5215512121212', ['52', '1', '55', '1212', '1212']    # Mexico City cell phone from abroad
+      it_splits '526641231212',  ['52', '664', '123', '1212']         # Tijuana
+      it_splits '5216641231212', ['52', '1', '664', '123', '1212']    # Tijuana cell phone from abroad
+      it_splits '520446641231212', ['52', '044', '664', '123', '1212']   # Tijuana cell phone local from landline
     end
     describe 'Monaco' do
       it_splits '37741123456', ['377', '41', '12', '34', '56'] # Mobile


### PR DESCRIPTION
Cell phones dialed from abroad require a '1' right after the country code. Also fixed up the splitting of numbers into 3-4 or 4-4 groups since this is what seems to be used according to the links below

http://en.wikipedia.org/wiki/Telephone_numbers_in_Mexico
http://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers#Mexico
