### PR TITLE
Modern Saudi Arabia phone formats

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -1002,7 +1002,14 @@ Phony.define do
               /\A8\d+\z/ => [3,3], # geographic
           )
 
-  country '966', fixed(1) >> split(3, 4) # Saudi Arabia (Kingdom of) http://www.wtng.info/wtng-966-sa.html
+  # Saudi Arabia (Kingdom of)
+  # http://www.wtng.info/wtng-966-sa.html
+  # http://www.citc.gov.sa/English/MediaCenter/awarenesscampaigns/Pages/PR_AWR_004.aspx
+  # http://en.wikipedia.org/wiki/Telephone_numbers_in_Saudi_Arabia
+  # https://answers.yahoo.com/question/index?qid=20090303142622AAQBoZ0
+  country '966',
+          match(/\A(5[0-9])\d+\z/) >> split(3,4) | # mobile numbers
+          fixed(3) >> split(3,4)
 
   # Yemen (Republic of)
   # https://www.numberingplans.com/?page=dialling&sub=areacodes

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -777,7 +777,8 @@ describe 'plausibility' do
                                                    '+378 512 345 6789']
       it_is_correct_for 'Sao Tome and Principe', :samples => ['+239 2 220 012',
                                                               '+239 9 920 012']
-      it_is_correct_for 'Saudi Arabia (Kingdom of)', :samples => '+966 5 296 3727'
+      it_is_correct_for 'Saudi Arabia (Kingdom of)', :samples => ['+966 50 296 3727',
+                                                                  '+966 011 307 4838']
       it_is_correct_for 'Senegal', :samples => '+221  1234 56789'
       it_is_correct_for 'Serbia', :samples => ['+381 800 123 45',
                                                ['+381 10 123 45', '+381 10 123 456'],

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -992,7 +992,8 @@ describe 'country descriptions' do
       it_splits '3785123456789', ['378', false, '512', '345', '6789']
     end
     describe 'Saudi Arabia (Kingdom of)' do
-      it_splits '96628528423', %w(966 2 852 8423)
+      it_splits '9660208528423', %w(966 020 852 8423)
+      it_splits '966506306201',  %w(966 50 630 6201)
     end
     describe 'Senegal' do
       it_splits '221123456789', ['221', false, '1234', '56789']


### PR DESCRIPTION
We have a client with a number 966 50 XXX XXXX which wasn't recognized by Phony so I went looking if there is any format changes and seems Phony uses old one that has been updated few times already.

Apparently, new formats should be
+966 5X XXX XXXX for mobile
+966 01X XXX XXXX for land lines

Here is some resources I found
http://www.citc.gov.sa/English/MediaCenter/awarenesscampaigns/Pages/PR_AWR_004.aspx
http://en.wikipedia.org/wiki/Telephone_numbers_in_Saudi_Arabia
https://answers.yahoo.com/question/index?qid=20090303142622AAQBoZ0
