### PR TITLE
Change Russian splitter from +7 495 000 0000 to +7 495 000 00 00

### DIFF
--- a/lib/phony/countries/russia_kazakhstan_abkhasia_south_ossetia.rb
+++ b/lib/phony/countries/russia_kazakhstan_abkhasia_south_ossetia.rb
@@ -110,19 +110,19 @@ ndcs_with_6_subscriber_digits = %w(3012 3022 3412 3435 3439 3452 3456 3462 3463 
   862 8634 8635 8636 8639 8652 8662 8672 8712 8722 8732 8772 8782 8793
 )
 
-ndcs_with_7_subscriber_digits = %w(342 343 347 351 383 391 473 495 496 498 499 812 818 831 843 844 846 861 862 863 
-  901 902 903 904 905 906 908 909 910 911 912 913 914 915 916 917 918 919 920 921 922 923 924 925 926 927 928 929 
-  930 931 932 933 934 936 937 938 950 951 952 953 960 961 962 963 964 965 967 968 980 981 982 983 984 985 987 988 
+ndcs_with_7_subscriber_digits = %w(342 343 347 351 383 391 473 495 496 498 499 812 818 831 843 844 846 861 862 863
+  901 902 903 904 905 906 908 909 910 911 912 913 914 915 916 917 918 919 920 921 922 923 924 925 926 927 928 929
+  930 931 932 933 934 936 937 938 950 951 952 953 960 961 962 963 964 965 967 968 980 981 982 983 984 985 987 988
   989 997
 )
 
 Phony.define do
-  country '7', 
+  country '7',
     trunk('8', normalize: false) |
-    one_of(ndcs_with_5_subscriber_digits)  >> split(1, 4) |
-    one_of(ndcs_with_6_subscriber_digits)  >> split(2, 4) |
-    one_of(ndcs_with_7_subscriber_digits)  >> split(3, 4) |
-    one_of(%w(800))                        >> split(3, 4) | # Russia free number
+    one_of(ndcs_with_5_subscriber_digits)  >> split(1, 2, 2) |
+    one_of(ndcs_with_6_subscriber_digits)  >> split(2, 2, 2) |
+    one_of(ndcs_with_7_subscriber_digits)  >> split(3, 2, 2) |
+    one_of(%w(800))                        >> split(3, 2, 2) | # Russia free number
     one_of(%w(995344 9971 99744 9976 997)) >> split(2, 4) | # South Osetia
     fixed(3)                               >> split(2, 5)
 end

--- a/spec/functional/format_spec.rb
+++ b/spec/functional/format_spec.rb
@@ -7,7 +7,7 @@ describe 'Phony#format' do
       Phony.formatted('41443643532').should eql '+41 44 364 35 32'
     end
   end
-  
+
   describe 'with templates' do
     it 'handles a basic template correctly' do
       Phony.format('41443643532', :format => 'A%{cc}B%{ndc}C%{local}').should eql 'A41B44C364 35 32'
@@ -25,7 +25,7 @@ describe 'Phony#format' do
   end
 
   describe 'cases' do
-    
+
     describe 'exceptions' do
       it 'raises on nil' do
         expect {
@@ -70,13 +70,13 @@ describe 'Phony#format' do
         Phony.format(Phony.normalize('+370 800 12345'), :format => :international).should eql '+370 800 12 345'
       end
       it 'should format Russian numbers' do
-        Phony.format(Phony.normalize('+7 812 123 4567'), :format => :international).should eql '+7 812 123 4567'
+        Phony.format(Phony.normalize('+7 812 123 4567'), :format => :international).should eql '+7 812 123 45 67'
       end
       it 'should format Russian numbers' do
         Phony.format(Phony.normalize('+370 800 12345'), :format => :national).should eql '8800 12 345'
       end
       it 'should format Russian numbers' do
-        Phony.format(Phony.normalize('+7 812 123 4567'), :format => :national).should eql '8812 123 4567'
+        Phony.format(Phony.normalize('+7 812 123 4567'), :format => :national).should eql '8812 123 45 67'
       end
     end
     describe 'international' do
@@ -183,7 +183,7 @@ describe 'Phony#format' do
         Phony.format('493038625454', :format => :local).should eql '386 25454'
       end
     end
-    
+
   end
 
 end

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -527,10 +527,10 @@ describe 'country descriptions' do
       it_splits '40249123123', ['40', '249', '123', '123'] # Olt
     end
     describe 'Russia' do
-      it_splits '78122345678',   ['7', '812', '234', '5678'] # Russia 3-digit
-      it_splits '74012771077',   ['7', '4012', '77', '1077'] # Russia 4-digit
-      it_splits '78402411212',   ['7', '84024', '1', '1212'] # Russia 5-digit
-      it_splits '79296119119',   ['7', '929', '611', '9119'] # Russia 3-digit, Megafon Mobile.
+      it_splits '78122345678',   ['7', '812', '234', '56', '78'] # Russia 3-digit
+      it_splits '74012771077',   ['7', '4012', '77', '10', '77'] # Russia 4-digit
+      it_splits '78402411212',   ['7', '84024', '1', '12', '12'] # Russia 5-digit
+      it_splits '79296119119',   ['7', '929', '611', '91', '19'] # Russia 3-digit, Megafon Mobile.
       it_splits '7840121212',    ['7', '840', '12', '1212']  # Abhasia
       it_splits '7799121212',    ['7', '799', '12', '1212']  # Kazachstan
       it_splits '7995344121212', ['7','995344','12','1212']   # South Osetia


### PR DESCRIPTION
There is more correct number splitting `+7 495 000 00 00` instead of `+7 495 000 0000`. As referenced [here](http://www.artlebedev.ru/kovodstvo/sections/91/) (same article but [in english](http://www.artlebedev.com/mandership/91/)) and on [wiki](https://ru.wikipedia.org/wiki/%D0%A2%D0%B5%D0%BB%D0%B5%D1%84%D0%BE%D0%BD%D0%BD%D1%8B%D0%B9_%D0%BD%D0%BE%D0%BC%D0%B5%D1%80).

I didn't change it for South Osetia and `fixed(3)` because don't know much about these cases.