### PR TITLE
update French Polynesia phone format (8 digits)

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -842,7 +842,7 @@ Phony.define do
   country '686', none >> split(2,3) # Kiribati (Republic of) http://www.wtng.info/wtng-686-ki.html
   country '687', none >> split(3,3) # New Caledonia (Territoire français d'outre-mer) http://www.wtng.info/wtng-687-nc.html
   country '688', none >> split(5) # Tuvalu http://www.wtng.info/wtng-688-tv.html
-  country '689', none >> split(3,3) # French Polynesia (Territoire français d'outre-mer) http://www.wtng.info/wtng-689-pf.html
+  country '689', none >> split(2,2,2,2) # French Polynesia (Territoire français d'outre-mer) http://www.wtng.info/wtng-689-pf.html
 
   country '690', fixed(1) >> split(3) # Tokelau http://www.wtng.info/wtng-690-tk.html
   country '691', none >> split(3, 4) # Micronesia (Federated States of) http://www.wtng.info/wtng-691-fm.html

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -579,7 +579,7 @@ describe 'plausibility' do
       it_is_correct_for 'Faroe Islands', :samples => '+298  969 597'
       it_is_correct_for 'Fiji (Republic of)', :samples => '+679  998 2441'
       it_is_correct_for 'French Guiana (French Department of)', :samples => '+594 594 123 456'
-      it_is_correct_for "French Polynesia (Territoire français d'outre-mer)", :samples => '+689  872 784 00'
+      it_is_correct_for "French Polynesia (Territoire français d'outre-mer)", :samples => '+689 87 27 84 00'
       it_is_correct_for 'Gabonese Republic', :samples => '+241 1 627 739'
       it_is_correct_for 'Gambia', :samples => '+220  989 5148'
       it_is_correct_for 'Germany', :samples => [

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -579,7 +579,7 @@ describe 'plausibility' do
       it_is_correct_for 'Faroe Islands', :samples => '+298  969 597'
       it_is_correct_for 'Fiji (Republic of)', :samples => '+679  998 2441'
       it_is_correct_for 'French Guiana (French Department of)', :samples => '+594 594 123 456'
-      it_is_correct_for "French Polynesia (Territoire français d'outre-mer)", :samples => '+689  872 784'
+      it_is_correct_for "French Polynesia (Territoire français d'outre-mer)", :samples => '+689  872 784 00'
       it_is_correct_for 'Gabonese Republic', :samples => '+241 1 627 739'
       it_is_correct_for 'Gambia', :samples => '+220  989 5148'
       it_is_correct_for 'Germany', :samples => [

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -773,7 +773,7 @@ describe 'country descriptions' do
       it_splits '594594123456', %w(594 594 123 456)
     end
     describe "French Polynesia (Territoire français d'outre-mer)" do
-      it_splits '689219889', ['689', false, '219', '889']
+      it_splits '68921988900', ['689', false, '21', '98', '89', '00']
     end
     describe 'Gabonese Republic' do
       it_splits '2411834375', ['241', '1', '834', '375']


### PR DESCRIPTION
add 2 digits to French Polynesia: 8 digits since sept-2014 (http://en.wikipedia.org/wiki/Telephone_numbers_in_French_Polynesia)
