### PR TITLE
Add support for Belgian mobile numbers owned by Telenet

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -75,6 +75,7 @@ Phony.define do
   #
   country '32', trunk('0') |
                 match(/^(70|800|90\d)\d+$/) >> split(3,3)   | # Service
+                match(/^(468)\d{6}$/)       >> split(6)     | # Mobile (Telenet)
                 match(/^(4[789]\d)\d{6}$/)  >> split(6)     | # Mobile
                 one_of('2','3','4','9')     >> split(3,2,2) | # Short NDCs
                 fixed(2)                    >> split(2,2,2)   # 2-digit NDCs

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -91,6 +91,7 @@ describe 'country descriptions' do
       it_splits '3245551414', ['32', '4', '555', '14', '14']   # Liège
       it_splits '3216473200', ['32', '16', '47', '32', '00']   # Leuven
       it_splits '32475279584', ['32', '475', '279584']     # mobile
+      it_splits '32468279584', ['32', '468', '279584']     # mobile (Telenet)
       it_splits '3270123123', ['32', '70', '123', '123']   # Bus Service?
     end
 


### PR DESCRIPTION
Phone already supports [Belgian mobile numbers](http://en.wikipedia.org/wiki/Telephone_numbers_in_Belgium#Mobile_numbers) that start with 047, 048 or 049, but Telenet owns a range of telephone numbers that start with 0468. 