### PR TITLE
Added support for nigerian numbers starting with 90[2359]

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -340,11 +340,12 @@ Phony.define do
   # Nigeria
   # Wikipedia says 3 4 split, many local number with no splitting
   country '234',
-    one_of('1', '2', '9')   >> split(3,4) | # Lagos, Ibadan and Abuja
-    match(/^(702\d)\d+$/)   >> split(3,4) | # Mobile
-    match(/^(70[3-9])\d+$/) >> split(3,4) | # Mobile
-    match(/^(8[01]\d)\d+$/) >> split(3,4) | # Mobile
-    fixed(2)                >> split(3,4)   # 2-digit NDC
+    match(/^(702\d)\d+$/)    >> split(3,4) | # Mobile
+    match(/^(70[3-9])\d+$/)  >> split(3,4) | # Mobile
+    match(/^(8[01]\d)\d+$/)  >> split(3,4) | # Mobile
+    match(/^(90[2359])\d+$/) >> split(3,4) | # Mobile
+    one_of('1', '2', '9')    >> split(3,4) | # Lagos, Ibadan and Abuja
+    fixed(2)                 >> split(3,4)   # 2-digit NDC
 
   country '235', none >> split(4,4) # Chad http://www.wtng.info/wtng-235-td.html
   country '236', none >> split(4,4) # Central African Republic http://www.wtng.info/wtng-236-cf.html

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -459,6 +459,7 @@ describe 'plausibility' do
       it 'is correct for Nigerian numbers' do
         Phony.plausible?('+234 807 766 1234').should be_true
         Phony.plausible?('+234 807 766 123').should be_false
+        Phony.plausible?('+234 909 123 1234').should be_true
       end
 
       it "is correct for Portugese numbers" do

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -942,6 +942,13 @@ describe 'country descriptions' do
     describe 'Niger' do
       it_splits '22712345678', ['227', false, '1234', '5678']
     end
+    describe 'Nigeria' do
+      it_splits '23411231234', %w(234 1 123 1234) # Lagos
+      it_splits '23470261231234', %w(234 7026 123 1234) # Mobile CDMA
+      it_splits '2347071231234', %w(234 707 123 1234) # Mobile
+      it_splits '2348051231234', %w(234 805 123 1234) # Mobile
+      it_splits '2349091231234', %w(234 909 123 1234) # Mobile
+    end
     describe 'Niue' do
       it_splits '6833651', ['683', false, '3651']
     end


### PR DESCRIPTION
our users reported that a nigerian number starting with 234 909 ~ was improperly marked as not valid, i did some research and many sources (including http://en.wikipedia.org/wiki/Telephone_numbers_in_Nigeria) indeed says its a valid number