### PR TITLE
Adds restrictions to North American NDCs.

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -35,7 +35,7 @@ Phony.define do
     # The US has a delimiter between NDC and local number.
     trunk('1%s', normalize: true) | # http://en.wikipedia.org/wiki/Trunk_prefix
     fixed(3) >> split(3,4),
-    :invalid_ndcs => ['911']
+    :invalid_ndcs => [/[0-2]{1}\d{2}/, /[0-9]{1}11/]
 
   # Kazakhstan (Republic of) & Russsian Federation.
   # also Abhasia and South Osetia autonomous regions / recognized by some states as independent countries

--- a/lib/phony/country.rb
+++ b/lib/phony/country.rb
@@ -97,7 +97,7 @@ module Phony
       #
       return false if ndc.nil?
       return false if ndc && ndc.empty?
-      return false if @invalid_ndcs.include? ndc # TODO Refactor.
+      return false if ( !@invalid_ndcs.empty? && ndc.match(Regexp.union(@invalid_ndcs)) )
 
       # # A valid range for the rest is 0 or 3+ total digits.
       # #

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -519,6 +519,8 @@ describe 'plausibility' do
         Phony.plausible?('1-800-692-7753').should be_true
         Phony.plausible?('1-911').should be_false
         Phony.plausible?('1-911-123-1234').should be_false
+        Phony.plausible?('1-411-123-1234').should be_false
+        Phony.plausible?('1-040-123-1234').should be_false
         Phony.plausible?('143466677777').should be_false # too long
         Phony.plausible?('143466677').should be_false # too short
 


### PR DESCRIPTION
I ran into a couple of issues when validating a US phone number via `Phony.plausible?`.

According to [this discussion](http://discuss.fogcreek.com/joelonsoftware3/default.asp?cmd=show&ixPost=102667&ixReplies=15) and [NANPA](http://www.nanpa.com/area_codes/index.html),  area codes in the US cannot start with 0, 1, or 2, and they also cannot be of the format `X11` where X is a number 0-9. 

Right now, invalid US phone numbers like `1-040-123-3333` or `1-411-123-3333` are being recognized as plausible by Phony. 

This pull request is an attempt to restrict those invalid area codes. 