### PR TITLE
Update Romanian rules for +40 79 mobile numbers

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -114,7 +114,7 @@ Phony.define do
   country '40',
           trunk('0') |
           match(/^(112|800|90[036])\d+$/) >> split(3,3) | # Service
-          match(/^(7[1-8])\d+$/)          >> split(3,4) | # Mobile
+          match(/^(7[1-9])\d+$/)          >> split(3,4) | # Mobile
           one_of('21', '31')              >> split(3,4) | # Bucureşti
           fixed(3)                        >> split(3,4)   # 3-digit NDCs
 

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -525,6 +525,7 @@ describe 'country descriptions' do
     describe 'Romania' do
       it_splits '40211231234', ['40', '21', '123', '1234'] # Bucureşti
       it_splits '40721231234', ['40', '72', '123', '1234'] # mobile
+      it_splits '40791231234', ['40', '79', '123', '1234'] # mobile
       it_splits '40249123123', ['40', '249', '123', '123'] # Olt
     end
     describe 'Russia' do


### PR DESCRIPTION
Updated rules and spec for Romanian '+40 79' mobile numbers