### PR TITLE
support Japanese 0x0 non-Geographic area codes with 11 digits numbers

### DIFF
--- a/lib/phony/countries/japan.rb
+++ b/lib/phony/countries/japan.rb
@@ -1,6 +1,25 @@
 # Japan
 # http://www.itu.int/oth/T020200006D/en
 
+ndcs_with_11_subscriber_numbers = %w(
+020
+030
+040
+050
+060
+070
+080
+090
+)
+
+ndcs_with_10_subscriber_numbers = %w(
+20
+50
+60
+70
+90
+)
+
 ndcs_with_8_subscriber_numbers = %w(3 6)
 
 ndcs_with_7_subscriber_numbers = %w(
@@ -402,12 +421,13 @@ ndcs_with_5_subscriber_numbers = %w(
 Phony.define do
   country '81',
     trunk('0') |
-    one_of(ndcs_with_5_subscriber_numbers) >> split(3,2) |
-    one_of(ndcs_with_6_subscriber_numbers) >> split(3,3) |
-    one_of(%w(120 800))                    >> split(3,3) | # freephone
-    one_of(ndcs_with_7_subscriber_numbers) >> split(4,3) |
-    one_of(ndcs_with_8_subscriber_numbers) >> split(4,4) |
-    one_of('20', '50', '60', '70', '90')   >> split(4,4) | # mobile, VoIP telephony
+    one_of(ndcs_with_5_subscriber_numbers)  >> split(3,2) |
+    one_of(ndcs_with_6_subscriber_numbers)  >> split(3,3) |
+    one_of(%w(120 800))                     >> split(3,3) | # freephone
+    one_of(ndcs_with_7_subscriber_numbers)  >> split(4,3) |
+    one_of(ndcs_with_8_subscriber_numbers)  >> split(4,4) |
+    one_of(ndcs_with_10_subscriber_numbers) >> split(4,4) | # mobile, VoIP telephony
+    one_of(ndcs_with_11_subscriber_numbers) >> split(4,4) | # 3-digit non-Geographic area codes (excluding 010)
     # TODO: 91(NDC) N(S)N length: 5-13 - Non-geographic number (Direct subscriber telephone service (legacy))
     fixed(2) >> split(4,4)
 end


### PR DESCRIPTION
Basing on https://en.wikipedia.org/wiki/Telephone_numbers_in_Japan#Non-geographic_area_codes + https://en.wikipedia.org/wiki/Telephone_numbers_in_Japan#Length_of_numbers
there are 11 digits long Japanese numbers that have Non geographic area codes 020, 030, 040, 050, 060, 070, 080, 090 (note that 010 is not included since it has special purpose).

This means valid phone numbers such as '+81 070 1234 5789' are rejected.

According to the same section, also 10 digits numbers with the same non geographic area codes could exist but when I tried modifying like this:
```
+ one_of(ndcs_with_11_subscriber_numbers) >> split(3,4) |
  one_of(ndcs_with_11_subscriber_numbers) >> split(4,4) | # 3-digit non-Geographic area codes (excluding 010)
```
'+81 070 1234 5789' -like numbers started getting rejected whereas '+81 070 123 5789' were accepted. Leaving those aside for now while I figure out where these types of numbers are coming from.