### PR TITLE
[Côte d'Ivoire]: Fixed parsing of mobile numbers and fixed splitting to ...

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -313,7 +313,16 @@ Phony.define do
 
   # country '224' # Guinea, see special file
 
-  country '225', none >> split(4,4) # Côte d'Ivoire http://www.wtng.info/wtng-225-ci.html
+  # Côte d'Ivoire
+  # http://www.wtng.info/wtng-225-ci.html
+  # http://www.itu.int/dms_pub/itu-t/oth/02/02/T02020000310001PDFE.pdf
+  # http://en.wikipedia.org/wiki/Telephone_numbers_in_Ivory_Coast
+  #
+  # There is no trunk code for this country and several of the mobile prefixes start with 0
+  country '225',
+    trunk('', :normalize => false) |
+    fixed(2) >> split(2,2,2)
+
   country '226', none >> split(4,4) # Burkina Faso http://www.wtng.info/wtng-226-bf.html
   country '227', none >> split(4,4) # Niger http://www.wtng.info/wtng-227-ne.html
   country '228', none >> split(4,4) # Togolese Republic http://www.wtng.info/wtng-228-tg.html

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -740,7 +740,8 @@ describe 'country descriptions' do
       it_splits '50622345678', %w(506 2 234 5678)
     end
     describe "Côte d'Ivoire" do
-      it_splits '22537335518', ['225', false, '3733', '5518']
+      it_splits '22507335518', ['225', '07', '33', '55', '18']
+      it_splits '22537335518', ['225', '37', '33', '55', '18']
     end
     describe 'Democratic Republic of Timor-Leste' do
       it_splits '6701742945', ['670', false, '174', '2945']


### PR DESCRIPTION
...reflect ITU specification

References:
[0] ITU
    http://www.itu.int/dms_pub/itu-t/oth/02/02/T02020000310001PDFE.pdf
[1] Telephone numbers in Ivory Coast
    http://en.wikipedia.org/wiki/Telephone_numbers_in_Ivory_Coast

Fixes:
The Ivory Coast numbers do not have a trunk code leading to the situation that valid numbers such as '22507123456' would be normalized as '2257123456'. Furthermore, if you look at the
allocation of both landline and mobile numbers given in both [0] and [1], the area code is fixed to 2 digits. In the case of landlines, the ITU spec will list out 3 digit area codes
but this is only because they are making the separation based on telecom provider as well. That is, the 3rd digit of the national subscriber number signifies the network operator. But viewing
it from the zones listed in the "Usage of E.164 number" column, it is clear that the zones are allocated 2-digits. This also matches up with the information in [1] as well as the way the
numbers are formatted in [0]

Côte d'Ivoire
Tel: +225 20 34 43 74
Fax: +225 20 34 43 75
URL: www.artci.ci

As a result, the parsing of Ivory Coast numbers will split the NSN into 4 2-digit numbers. Furthermore, we need to set the trunk code to an empty string to prevent it from being removed
during normalization (similar to how it is done for Italy)