### PR TITLE
Formatting: separate BE mobile numbers by 2 digits.

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -95,8 +95,8 @@ Phony.define do
   #
   country '32', trunk('0') |
                 match(/^(70|800|90\d)\d+$/) >> split(3,3)   | # Service
-                match(/^(468)\d{6}$/)       >> split(6)     | # Mobile (Telenet)
-                match(/^(4[789]\d)\d{6}$/)  >> split(6)     | # Mobile
+                match(/^(468)\d{6}$/)       >> split(2,2,2) | # Mobile (Telenet)
+                match(/^(4[789]\d)\d{6}$/)  >> split(2,2,2) | # Mobile
                 one_of('2','3','4','9')     >> split(3,2,2) | # Short NDCs
                 fixed(2)                    >> split(2,2,2)   # 2-digit NDCs
 

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -85,14 +85,14 @@ describe 'country descriptions' do
 
     describe 'Belgium' do
       it_splits '3235551212', ['32', '3', '555', '12', '12']   # Antwerpen
-      it_splits '3250551212', ['32', '50', '55', '12', '12'] # Brugge
+      it_splits '3250551212', ['32', '50', '55', '12', '12']   # Brugge
       it_splits '3225551212', ['32', '2', '555', '12', '12']   # Brussels
       it_splits '3295551914', ['32', '9', '555', '19', '14']   # Gent
       it_splits '3245551414', ['32', '4', '555', '14', '14']   # Liège
       it_splits '3216473200', ['32', '16', '47', '32', '00']   # Leuven
-      it_splits '32475279584', ['32', '475', '279584']     # mobile
-      it_splits '32468279584', ['32', '468', '279584']     # mobile (Telenet)
-      it_splits '3270123123', ['32', '70', '123', '123']   # Bus Service?
+      it_splits '32475279584', ['32', '475', '27', '95', '84'] # mobile
+      it_splits '32468279584', ['32', '468', '27', '95', '84'] # mobile (Telenet)
+      it_splits '3270123123', ['32', '70', '123', '123']       # Bus Service?
     end
 
     describe 'Belize' do


### PR DESCRIPTION
Belgian mobile numbers had the last 6 numbers bundled, which affected readability once formatted. 
If there's a specific reason, please ignore this, but I can't seem to find one.

Before : +32 495 123456
After : +32 495 12 34 56