### PR TITLE
Improve japanese

### DIFF
--- a/lib/phony/countries/japan.rb
+++ b/lib/phony/countries/japan.rb
@@ -402,12 +402,13 @@ ndcs_with_5_subscriber_numbers = %w(
 Phony.define do
   country '81',
     trunk('0') |
-    one_of(ndcs_with_5_subscriber_numbers) >> split(3,2) |
-    one_of(ndcs_with_6_subscriber_numbers) >> split(3,3) |
+    one_of(ndcs_with_5_subscriber_numbers) >> split(1,4) |
+    one_of(ndcs_with_6_subscriber_numbers) >> split(2,4) |
     one_of(%w(120 800))                    >> split(3,3) | # freephone
-    one_of(ndcs_with_7_subscriber_numbers) >> split(4,3) |
+    one_of(ndcs_with_7_subscriber_numbers) >> split(3,4) |
     one_of(ndcs_with_8_subscriber_numbers) >> split(4,4) |
     one_of('20', '50', '60', '70', '90')   >> split(4,4) | # mobile, VoIP telephony
     # TODO: 91(NDC) N(S)N length: 5-13 - Non-geographic number (Direct subscriber telephone service (legacy))
-    fixed(2) >> split(4,4)
+    fixed(2) >> split(4,4),
+    :local_space => :-
 end

--- a/lib/phony/countries/japan.rb
+++ b/lib/phony/countries/japan.rb
@@ -402,13 +402,14 @@ ndcs_with_5_subscriber_numbers = %w(
 Phony.define do
   country '81',
     trunk('0') |
+    one_of('20', '50', '60', '70', '90')   >> split(4,4) | # mobile, VoIP telephony
     one_of(ndcs_with_5_subscriber_numbers) >> split(1,4) |
     one_of(ndcs_with_6_subscriber_numbers) >> split(2,4) |
     one_of(%w(120 800))                    >> split(3,3) | # freephone
     one_of(ndcs_with_7_subscriber_numbers) >> split(3,4) |
     one_of(ndcs_with_8_subscriber_numbers) >> split(4,4) |
-    one_of('20', '50', '60', '70', '90')   >> split(4,4) | # mobile, VoIP telephony
     # TODO: 91(NDC) N(S)N length: 5-13 - Non-geographic number (Direct subscriber telephone service (legacy))
     fixed(2) >> split(4,4),
-    :local_space => :-
+    :local_space => :- ,
+    :space => :-
 end

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -373,12 +373,18 @@ describe 'country descriptions' do
       it_splits '390471811353', ['39', '0471', '811', '353'] # Bolzano
     end
     describe 'Japan' do
-      it_splits '81312345678', %w(81 3 1234 5678)
-      it_splits '81120123456', %w(81 120 123 456)
+      it_splits '81312345678', %w(81 3 1234 5678) # Tokyo
+      it_splits '81612345678', %w(81 6 1234 5678) # Osaka
+      it_splits '81120123456', %w(81 120 123 456) # Freephone
       it_splits '81111234567', %w(81 11 123 4567)
       it_splits '81123123456', %w(81 123 12 3456)
       it_splits '81126712345', %w(81 1267 1 2345)
-      it_splits '819012345678', %w(81 90 1234 5678)
+      it_splits '812012345678', %w(81 20 1234 5678) # Pager(Calling Party Pay)
+      it_splits '815012345678', %w(81 50 1234 5678) # IP Telephone
+      it_splits '816012345678', %w(81 60 1234 5678) # UPT
+      it_splits '817012345678', %w(81 70 1234 5678) # PHS
+      it_splits '818012345678', %w(81 80 1234 5678) # Cellular
+      it_splits '819012345678', %w(81 90 1234 5678) # Cellular
     end
     describe 'Kenya' do
       it_splits '254201234567', ['254', '20', '1234567'] # Nairobi

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -375,9 +375,9 @@ describe 'country descriptions' do
     describe 'Japan' do
       it_splits '81312345678', %w(81 3 1234 5678)
       it_splits '81120123456', %w(81 120 123 456)
-      it_splits '81111234567', %w(81 11 1234 567)
-      it_splits '81123123456', %w(81 123 123 456)
-      it_splits '81126712345', %w(81 1267 123 45)
+      it_splits '81111234567', %w(81 11 123 4567)
+      it_splits '81123123456', %w(81 123 12 3456)
+      it_splits '81126712345', %w(81 1267 1 2345)
       it_splits '819012345678', %w(81 90 1234 5678)
     end
     describe 'Kenya' do


### PR DESCRIPTION
Hi,
Thank you for the great lib. 

I wish improve lib to Japanese telephone number.
Telephone number in Japan is:
* usually [Area Code] - [Local Exchange Number] - [Subscriber Number].
* [Subscriber Number] is 4 digits.
* Osaka's area code (6) and UPT code (60) are confused.

see also: http://www.soumu.go.jp/main_sosiki/joho_tsusin/eng/TelNumber/Numbering.html