### PR TITLE
accept shorter mobile numbers and service/subscriber numbers for Finland

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -624,9 +624,10 @@ Phony.define do
   #
   country '358',
           trunk('0') |
+          match(/^([1-3]0)\d+$/)          >> split(3,3,0..6) | # Service/subscriber
           match(/^([6-8]00)\d+$/)         >> split(3,3)   | # Service
-          match(/^(4\d|50)\d+$/)          >> split(3,2,2) | # Mobile
-          one_of('2','3','5','6','8','9') >> split(3,3)   | # Short NDCs
+          match(/^(4\d|50)\d+$/)          >> split(3,2,0..2) | # Mobile
+          one_of('2','3','5','6','8','9') >> split(3,2..4)   | # Short NDCs
           fixed(2)                        >> split(3,3)     # 2-digit NDCs
 
   # Bulgaria

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -62,6 +62,15 @@ describe 'plausibility' do
       it_is_correct_for 'Falkland Islands (Malvinas)', :samples => '+500  28494'
       it_is_correct_for 'Faroe Islands', :samples => '+298  969 597'
       it_is_correct_for 'Fiji (Republic of)', :samples => '+679  998 2441'
+      it 'is correct for Finland' do
+        Phony.plausible?('+358 50 123 45').should be_true
+        Phony.plausible?('+358 50 123 45 6').should be_true
+        Phony.plausible?('+358 50 123 45 67').should be_true
+        Phony.plausible?('+358 9 123 45').should be_true
+        Phony.plausible?('+358 9 123 456').should be_true
+        Phony.plausible?('+358 9 123 4567').should be_true
+        Phony.plausible?('+358 20 1470 740').should be_true
+      end
       it_is_correct_for 'French Guiana (French Department of)', :samples => '+594 594 123 456'
       it_is_correct_for "French Polynesia (Territoire français d'outre-mer)", :samples => '+689 87 27 84 00'
       it_is_correct_for 'Gabonese Republic', :samples => '+241 1 627 739'


### PR DESCRIPTION
According to the specifications from the Finnish Communications Regulatory Authority (see [here](https://www.viestintavirasto.fi/attachments/Suomen_numerointisuunnitelma.XLSX)), the length of mobile phone and landline numbers can vary within a certain range (e.g. mobile numbers can be between 6 and 10 digits long). 

Also, service and national subscriber numbers starting 010, 020, 030 should be accepted as valid numbers.