### PR TITLE
Ensure that El Salvador numbers are plausible

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -732,7 +732,7 @@ Phony.define do
           fixed(1) >> split(3,4)
 
    # El Salvador (Republic of)
-  country '503', fixed(4) >> split(4,4)
+  country '503', fixed(4) >> split(4)
 
   # Honduras (Republic of) http://www.wtng.info/wtng-504-hn.html
   # https://www.numberingplans.com/?page=dialling&sub=areacodes

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -177,6 +177,10 @@ describe 'plausibility' do
       it_is_correct_for 'Reunion / Mayotte (new)', :samples => '+262 295 276 964'
       it_is_correct_for 'Saint Helena', :samples => '+290  5134'
       it_is_correct_for 'Saint Pierre and Miquelon (Collectivité territoriale de la République française)', :samples => '+508  474 714'
+      it_is_correct_for 'Salvador (El)', :samples => [
+                                                       '+503 2112 1234',
+                                                       '+503 6112 1234'
+                                                     ]
       it_is_correct_for 'Samoa (Independent State of)', :samples => ['+685 800 123',
                                                                      '+685 61 123',
                                                                      '+685 721 2345',


### PR DESCRIPTION
We noticed that El Salvador numbers weren't considered plausible, e.g. "+503 2112 1234".

According to the [official documentation](http://www.itu.int/dms_pub/itu-t/oth/02/02/T020200003F0001PDFE.pdf):

> The numbering plan for the Republic of El Salvador uses the following numbering structure:
> * for services provided through access networks, eight (8) digits, including the National
Destination Code (NDC),
 freephone numbers and premium rate numbers use seven (7) and eleven (11) digits.
> * numbers for the international long distance service through operator, use seven(7)-digit
numbering.
> * the three(3)-digit numbers are used for the selection code for the multicarrier system and
special services.
> * a 6-digit number has been assigned for the children helpline.

In the short term 8 digits would fix the problem that we are encountering.

I think that this change is the right way to solve the problem, but my apologies if I've done something wrong! :)

References:

* http://www.itu.int/dms_pub/itu-t/oth/02/02/T020200003F0001PDFE.pdf
* https://en.wikipedia.org/wiki/Telephone_numbers_in_El_Salvador