### PR TITLE
Better national format for Martinique, Guadeloupe, and Reunion Islands

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -476,7 +476,9 @@ Phony.define do
               /\A6\d+\z/ => [3,3,3]   # satellite
           )
 
-  country '262', fixed(3) >> split(3, 3) # Reunion / Mayotte (new) http://www.wtng.info/wtng-262-fr.html
+  country '262', # Reunion / Mayotte (new) http://www.wtng.info/wtng-262-fr.html
+    trunk('0') |
+    fixed(3) >> split(2,2,2)
 
   # country '263' # Zimbabwe, see special file
 
@@ -769,7 +771,8 @@ Phony.define do
 
   # Guadeloupe (French Department of) http://www.wtng.info/wtng-590-fr.html
   # https://www.numberingplans.com/?page=dialling&sub=areacodes
-  country '590', fixed(3) >> split(3,3)
+  country '590', trunk('0') |
+    fixed(3) >> split(2,2,2)
 
   country '591', # Bolivia (Republic of) http://www.itu.int/oth/T020200001A/en
     fixed(1) >> split(3,4)
@@ -787,7 +790,8 @@ Phony.define do
   # country '595' # Paraguay (Republic of), see special file
 
   # Martinique (French Department of) http://www.wtng.info/wtng-596-mq.html, https://www.numberingplans.com
-  country '596', fixed(3) >> split(3, 3)
+  country '596', trunk('0') |
+    fixed(3) >> split(2,2,2)
 
   # Suriname (Republic of) http://www.wtng.info/wtng-597-sr.html, https://www.numberingplans.com
   country '597',

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -797,7 +797,7 @@ describe 'country descriptions' do
       it_splits '299691123', ['299', '691', '123']
     end
     describe 'Guadeloupe (French Department of)' do
-      it_splits '590123456789', %w(590 123 456 789)
+      it_splits '590590456789', %w(590 590 45 67 89)
     end
     describe 'Guatemala (Republic of)' do
       it_splits '50219123456789', ['502', '19', '123', '456', '789']
@@ -897,7 +897,7 @@ describe 'country descriptions' do
       it_splits '6924226536', ['692', false, '422', '6536']
     end
     describe 'Martinique (French Department of)' do
-      it_splits '596596123456', %w(596 596 123 456)
+      it_splits '596596123456', %w(596 596 12 34 56)
     end
     describe 'Mauritania' do
       it_splits '22212345678', ['222', false, '1234', '5678']
@@ -1027,7 +1027,7 @@ describe 'country descriptions' do
       it_splits '67511512345678', %w(675 115 1234 5678)
     end
     describe 'Reunion / Mayotte (new)' do
-      it_splits '262594399265', ['262', '594', '399', '265']
+      it_splits '262594399265', ['262', '594', '39', '92', '65']
     end
     describe 'Saint Helena' do
       it_splits '2903614', ['290', false, '3614']


### PR DESCRIPTION
People from those French territories usually split phone numbers saying
4,2,2,2 (for 0590112233 => 0590 11 22 33).