### PR TITLE
Allow longer numbers for ndcs in Austria

### DIFF
--- a/lib/phony/countries/austria.rb
+++ b/lib/phony/countries/austria.rb
@@ -87,7 +87,7 @@ Phony.define do
                 one_of('1')       >> split(3..12) | # Vienna
                 one_of(service)   >> split(9..9) |
                 one_of(corporate) >> split(5..5) |
-                one_of(ndcs)      >> split(6..6) |
+                one_of(ndcs)      >> split(6..10) |
                 one_of('663')     >> split(6..6) | # 6 digit mobile.
                 one_of(mobile)    >> split(4,3..9) |
                 one_of(mobile_2digit) >> split(7..7) | # Separate as mobile contains 676 - 67 violates the prefix rule.

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -82,6 +82,7 @@ Some of the examples use `plausible? true: [some numbers]`.
     Phony.refute.plausible?('+43 501 1234') # too short
     Phony.refute.plausible?('+43 501 123456') # too long
     Phony.assert.plausible?('+43 800 123456789')
+    Phony.assert.plausible?('+43 512 1234567890')
     Phony.assert.plausible?('+43 3115 3307') # See issue #246 on Github.
 
 Mobile.


### PR DESCRIPTION
Hi again =)

I've encountered some Austrian phone numbers which are longer than phony expects (6 digits past the ndc). The [spec](https://www.rtr.at/en/tk/E129) appears to allow for numbers in Innsbruck (`512`) as long as 13 digits, I only spotted 10 in the wild ([Hotel Ramada](http://www.ramada.com/hotels/austria/innsbruck/ramada-innsbruck-tivoli/hotel-overview)) and the actual number causing issues for me had only 7.

Happy to add any other changes/suggestions as needed.