### PR TITLE
Add 9th digit to brazilian mobile numbers when NDC starts with 3 or 7

### DIFF
--- a/lib/phony/countries/brazil.rb
+++ b/lib/phony/countries/brazil.rb
@@ -100,7 +100,7 @@ ndcs = {
 }
 
 regular_phone_or_mobile = /\A(#{ndcs.values.join('|')})\d{8}\z/
-mobile_with_9_digits = /\A(#{ndcs[1]}|#{ndcs[2]}|#{ndcs[8]}|#{ndcs[9]}|#{ndcs[3]})9\d{8}\z/
+mobile_with_9_digits = /\A(#{ndcs[1]}|#{ndcs[2]}|#{ndcs[8]}|#{ndcs[9]}|#{ndcs[3]}|#{ndcs[7]})9\d{8}\z/
 
 service = %w{ 100 128 190 191 192 193 194 197 198 199 } # State specific numbers were not added. See http://www.brasil.gov.br/navegue_por/aplicativos/agenda
 

--- a/lib/phony/countries/brazil.rb
+++ b/lib/phony/countries/brazil.rb
@@ -87,7 +87,20 @@
  # 98 #Maranhão
  # 99 #Maranhão
 
-ndcs = /(11|12|13|14|15|16|17|18|19|21|22|24|27|28|31|32|33|34|35|36|37|38|41|42|43|44|45|46|47|48|49|51|52|53|54|55|61|62|63|64|65|66|67|68|69|71|72|73|74|75|77|78|79|81|82|83|84|85|86|87|88|89|91|92|93|94|95|96|97|98|99)\d{8}/
+ndcs = {
+  1 => '1[1-9]',
+  2 => '2[12478]',
+  3 => '3[1-8]',
+  4 => '4[1-9]',
+  5 => '5[1-5]',
+  6 => '6[1-9]',
+  7 => '7[12345789]',
+  8 => '8[1-9]',
+  9 => '9[1-9]'
+}
+
+regular_phone_or_mobile = /\A(#{ndcs.values.join('|')})\d{8}\z/
+mobile_with_9_digits = /\A(#{ndcs[1]}|#{ndcs[2]}|#{ndcs[8]}|#{ndcs[9]}|#{ndcs[3]})9\d{8}\z/
 
 service = %w{ 100 128 190 191 192 193 194 197 198 199 } # State specific numbers were not added. See http://www.brasil.gov.br/navegue_por/aplicativos/agenda
 
@@ -96,10 +109,10 @@ special_numbers_4 = %w{ 3003 4004 4020 }
 
 Phony.define do
   country '55',
-    match(/^(11|12|13|14|15|16|17|18|19|21|22|24|27|28|81|82|83|84|85|86|87|88|89|91|92|93|94|95|96|97|98|99)9\d{8}$/) >> split(5,4) |
-    match(ndcs)                  >> split(4,4) |
-    one_of(special_numbers_3_4)  >> split(3,4) |
-    one_of(special_numbers_4)    >> split(4) |
-    one_of(service)              >> split(3) |
-    fixed(3)                     >> split(3)
+    match(mobile_with_9_digits)       >> split(5,4) |
+    match(regular_phone_or_mobile)    >> split(4,4) |
+    one_of(special_numbers_3_4)       >> split(3,4) |
+    one_of(special_numbers_4)         >> split(4) |
+    one_of(service)                   >> split(3) |
+    fixed(3)                          >> split(3)
 end

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -125,7 +125,13 @@ describe 'country descriptions' do
       it_splits '5519991311234', ['55', '19', '99131', '1234'] # Rio de Janeiro's 9 digits mobile
 
       context "special states with 9 in mobile" do
-        %w{ 11 12 13 14 15 16 17 18 19 21 22 24 27 28 81 82 83 84 85 86 87 88 89 91 92 93 94 95 96 97 98 99}.each do |state_code|
+        %w{
+          11 12 13 14 15 16 17 18 19
+          21 22 24 27 28
+          81 82 83 84 85 86 87 88 89
+          91 92 93 94 95 96 97 98 99
+          31 32 33 34 35 36 37 38
+        }.each do |state_code|
           it_splits "55#{state_code}993051123", ['55', state_code, '99305', '1123']
         end
       end
@@ -142,6 +148,7 @@ describe 'country descriptions' do
         it_splits '55199', ['55', '199', ""]
       end
     end
+
     describe 'Cambodia' do
       it_splits '85512236142', ["855", "12", "236", "142"]   # mobile (Mobitel)
       it_splits '855977100872', ["855", "97", "710", "0872"] # mobile (Metfone)

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -131,6 +131,7 @@ describe 'country descriptions' do
           81 82 83 84 85 86 87 88 89
           91 92 93 94 95 96 97 98 99
           31 32 33 34 35 36 37 38
+          71 72 73 74 75 77 78 79
         }.each do |state_code|
           it_splits "55#{state_code}993051123", ['55', state_code, '99305', '1123']
         end


### PR DESCRIPTION
Anatel has determined that mobile numbers with NDCs 7 and 3 will be migrated to the 9th pattern until December of 2015, as you can see in topic 10 (portuguese): 

http://www.anatel.gov.br/Portal/exibirPortalPaginaEspecial.do?org.apache.struts.taglib.html.TOKEN=9594e1d11fbc996d52bda44e608bb744&acao=carregaPasta&codItemCanal=1794&pastaSelecionada=2984