### PR TITLE
Adds 465 as a valid prefix for Belgium

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -97,7 +97,7 @@ Phony.define do
   #
   country '32', trunk('0') |
                 match(/^(70|800|90\d)\d+$/) >> split(3,3)   | # Service
-                match(/^(46[68])\d{6}$/)    >> split(2,2,2) | # Mobile (Lycamobile, Telenet)
+                match(/^(46[568])\d{6}$/)   >> split(2,2,2) | # Mobile (Lycamobile, Telenet)
                 match(/^(4[789]\d)\d{6}$/)  >> split(2,2,2) | # Mobile
                 one_of('2','3','4','9')     >> split(3,2,2) | # Short NDCs
                 fixed(2)                    >> split(2,2,2)   # 2-digit NDCs
@@ -707,11 +707,11 @@ Phony.define do
 
   country '387', trunk('0') | fixed(2) >> split(3,2,2) # Bosnia and Herzegovina
   country '388', trunk('0') | fixed(2) >> split(3,2,2) # Group of countries, shared code
-  
+
   # The Former Yugoslav Republic of Macedonia
   country '389',
-  	  trunk('0') | 
-  	  one_of('2','3','4','5','6','7','8')  >> split(3,4)
+      trunk('0') |
+      one_of('2','3','4','5','6','7','8')  >> split(3,4)
 
   country '420', fixed(3) >> split(3,3) # Czech Republic
 

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -163,6 +163,7 @@ NDC with several subscriber number length.
     Phony.assert.plausible?('+32 3 241 11 32')
     Phony.assert.plausible?('0032 3 241 11 32')
     Phony.assert.plausible?('0032 (0) 3 241 11 32')
+    Phony.assert.plausible?('+32 465 12 34 56')
     Phony.assert.plausible?('+32 466 12 34 56')
     Phony.assert.plausible?('+32 468 12 34 56')
     Phony.assert.plausible?('+32 471 12 34 56')


### PR DESCRIPTION
The company I work for uses Phony to validate phone numbers and recently ran into an issue where some valid numbers from Belgium are rejected. This adds the missing prefix to Phony.

Note: My editor automatically fixes trailing whitespace and bad indentation, which I included in the commit.