### PR TITLE
Corrected number of digits for Australian 1300 and 1800 numbers.

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -236,8 +236,8 @@ Phony.define do
   country '61',
     trunk('0') |
     match(/^(4\d\d)\d+$/) >> split(3,3) | # Mobile
-    match(/^(1800)\d+$/)  >> split(4,4) | # 1800 free call
-    match(/^(1300)\d+$/)  >> split(4,4) | # 1300 local rate
+    match(/^(1800)\d+$/)  >> split(3,3) | # 1800 free call
+    match(/^(1300)\d+$/)  >> split(3,3) | # 1300 local rate
     match(/^(13)\d+$/)    >> split(2,2) | # 13 local rate
     fixed(1)              >> split(4,4)   # Rest
 

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -106,8 +106,8 @@ Mobile numbers can have from 7 to 10 digits in the subscriber number.
 #### Australia
 
     Phony.assert.plausible?('+614 1234 5678')
-    Phony.assert.plausible?('+61 1800 1234 5678')
-    Phony.assert.plausible?('+61 1300 1234 5678')
+    Phony.assert.plausible?('+61 1800 123 456')
+    Phony.assert.plausible?('+61 1300 123 456')
     Phony.assert.plausible?('+61 13 12 12')
     Phony.assert.plausible?('+613 1234 5678')
     Phony.refute.plausible?('+613 1234 56789') # too long

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -57,8 +57,8 @@ describe 'country descriptions' do
       it_splits '61512341234', ['61', '5', '1234', '1234'] # Landline
       it_splits '61423123123', ['61', '423', '123', '123'] # Mobile
       it_splits '61131212', ['61', '13', '12', '12'] # 13 local rate
-      it_splits '61130012341234', ['61', '1300', '1234', '1234'] # 1300 local rate
-      it_splits '61180012341234', ['61', '1800', '1234', '1234'] # 1800 free call
+      it_splits '611300123123', ['61', '1300', '123', '123'] # 1300 local rate
+      it_splits '611800123123', ['61', '1800', '123', '123'] # 1800 free call
     end
 
     describe 'Bahrain' do


### PR DESCRIPTION
Apologies, my initial PR incorrectly expected 8 digits after the 1300 and 1800 numbers, when it should have been 6.