### PR TITLE
Romanian numbers w/ 3-digit NDC should appear 40-249-123-123

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -136,7 +136,7 @@ Phony.define do
           match(/^(112|800|90[036])\d+$/) >> split(3,3) | # Service
           match(/^(7[1-9])\d+$/)          >> split(3,4) | # Mobile
           one_of('21', '31')              >> split(3,4) | # Bucureşti
-          fixed(3)                        >> split(3,4)   # 3-digit NDCs
+          fixed(3)                        >> split(3,3)   # 3-digit NDCs
 
   # Switzerland.
   #

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -776,6 +776,15 @@ With regexp constraints.
     Phony.assert.plausible?('+351 123 123456')
     Phony.refute.plausible?('+351 123 1234567')
 
+#### Romania
+
+    plausible? true: [
+      '+40 21 123 1234',
+      '+40 72 123 1234',
+      '+40 79 123 1234',
+      '+40 249 123 123'
+    ]
+
 #### Russia
 
     Phony.assert.plausible?('+7 800 2000 600')


### PR DESCRIPTION
We noticed that certain Romanian numbers weren't considered plausible, e.g. "+40-249-123-123".

According to the [World Telephone Numbering Guide](http://www.wtng.info/wtng-40-ro.html) and [the Wikipedia article for 'Telephone numbers in Romania'](https://en.wikipedia.org/wiki/Telephone_numbers_in_Romania), "+40-249-123-123" should be a valid number.