### PR TITLE
Add support for Dutch machine-to-machine numbers

### DIFF
--- a/lib/phony/countries/netherlands.rb
+++ b/lib/phony/countries/netherlands.rb
@@ -1,4 +1,5 @@
-# The Netherlands use a variable-length ndc code, thus we use a separate file to not let all_other.rb explode.
+# The Netherlands use a variable-length ndc code, thus we use a separate file to not let all_other.rb explode. The
+# latest version of the numbering plan is available at http://wetten.overheid.nl/BWBR0010198/
 #
 # Note: The netherlands use a variable ndc format from length 2 to 3.
 #       To save space, we only use ndcs of length 2 (and use the fallback of 3 to handle the rest).
@@ -56,6 +57,7 @@ service3 = [
 Phony.define do
   country '31',
     trunk('0', :normalize => true)                |
+    match(/\A(97[0,9])\d{8}\z/) >> split(4,4)     | # machine-to-machine
     one_of(service)             >> split(4,3)     |
     match(/\A(800|900)\d{4}\z/) >> split(4)       |
     one_of(service3)            >> split(4,3)     |

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -659,6 +659,9 @@ With regexp constraints.
     Phony.assert.plausible?('+31 900 123 4567')
     Phony.refute.plausible?('+31 900 001 00')
     Phony.assert.plausible?('+31 800 6080')
+    Phony.assert.plausible?('+31 970 1234 5678')
+    Phony.refute.plausible?('+31 971 2345 6789')
+    Phony.assert.plausible?('+31 979 0000 0000')
 
 #### New Zealand
 

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -484,6 +484,7 @@ describe 'country descriptions' do
       it_splits '31612345678', ['31', '6', '12', '34', '56', '78'] # mobile
       it_splits '31201234567', ['31', '20', '123', '4567']
       it_splits '31222123456', ['31', '222', '123', '456']
+      it_splits '3197012345678', ['31', '970', '1234', '5678'] # machine-to-machine
     end
     describe 'Norway' do
       it_splits '4721234567', ['47',false,'21','23','45','67']


### PR DESCRIPTION
These numbers are mandatory for non-voice devices such as laptops, tablets, security camera's, etc since June 1st, 2014.

0970 numbers are in use now, with the 0971-0978 ranges reserved for future use. 0979 is for network internal usage.