### PR TITLE
Add support for 5 digit Swedish numbers and extend NDCS list

### DIFF
--- a/lib/phony/countries/sweden.rb
+++ b/lib/phony/countries/sweden.rb
@@ -9,31 +9,32 @@
 
 ndcs = [
  # '7',  # Non-geographic - conflicts with mobile
- '8',  # Stockholm
- '10', # VOIP
- '11', # Norrköping
- '13', # Linköping
- '16', # Eskilstuna-Torshälla
- '18', # Uppsala
- '19', # Örebro-Kumla
- '20', # toll-free
- '21', # Västerås
- '23', # Falun
- '26', # Gävle-Sandviken
- '31', # Göteborg
- '33', # Borås
- '35', # Halmstad
- '36', # Jönköping-Huskvarna
- '40', # Malmö
- '42', # Helsingborg-Höganäs
- '44', # Kristianstad
- '46', # Lund
- '54', # Karlstad
- '60', # Sundsvall-Timrå
- '63', # Östersund
- '90', # Umeå
+  '8',  # Stockholm
+  '10', # VOIP
+  '11', # Norrköping
+  '13', # Linköping
+  '16', # Eskilstuna-Torshälla
+  '18', # Uppsala
+  '19', # Örebro-Kumla
+  '20', # toll-free
+  '21', # Västerås
+  '23', # Falun
+  '26', # Gävle-Sandviken
+  '31', # Göteborg
+  '33', # Borås
+  '35', # Halmstad
+  '36', # Jönköping-Huskvarna
+  '40', # Malmö
+ '417', # Tomelilla
+  '42', # Helsingborg-Höganäs
+  '44', # Kristianstad
+  '46', # Lund
+  '54', # Karlstad
+  '60', # Sundsvall-Timrå
+  '63', # Östersund
+  '90', # Umeå
  '522', # Uddevalla
- '77', #Dalarna
+  '77', #Dalarna
 ]
 mobile = [
  '70', # Mobile
@@ -61,7 +62,7 @@ Phony.define do
     trunk('0') |
     one_of(service)       >> split(3,3)   |
     one_of(ndcs + mobile) >> matched_split(
-      /^\d{6}$/ => [2, 2, 2], /^\d{7}$/ => [3, 2, 2], /^\d{8}$/ => [3, 2, 3]
+      /^\d{5}$/ => [3, 2], /^\d{6}$/ => [2, 2, 2], /^\d{7}$/ => [3, 2, 2], /^\d{8}$/ => [3, 2, 3]
     ) |
     fixed(3)              >> split(3,3,2)   # catchall
 end

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -817,6 +817,7 @@ With regexp constraints.
     Phony.assert.plausible?('+46 8 506 106 00')
     Phony.assert.plausible?('+46 19 764 22 00')
     Phony.assert.plausible?('+46 19 20 88 50')
+    Phony.assert.plausible?('+46 42 123 45')
     Phony.assert.plausible?('+46 79 123 45 67')
     Phony.refute.plausible?('+46 19 20 88') # too short
 

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -228,7 +228,7 @@ describe 'plausibility' do
                                                     '+211 973 212 345']
       it_is_correct_for 'Suriname (Republic of)', :samples => ['+597 212 345', '+597 612 3456']
       it_is_correct_for 'Swaziland', :samples => ['+268 2207 1234', '+268 550 1234']
-      it_is_correct_for 'Sweden', :samples => ['+46 522 636 365']
+      it_is_correct_for 'Sweden', :samples => ['+46 42 123 45', ['+46 417 123 45', '+46 522 636 365']]
       it_is_correct_for 'Syrian Arab Republic', :samples => ['+963 11 123 4567',
                                                              '+963 31 123 4567',
                                                              '+963 15 731 234',

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -643,6 +643,7 @@ describe 'country descriptions' do
       it_splits '46791234567', ['46', '79', '123', '45', '67'] # mobile
       it_splits '46125123456', ['46', '125', '123', '456']
       it_splits '46770820180', ['46', '77', '082', '01', '80']
+      it_splits '4641712345',  ['46', '417', '123', '45']
     end
     describe 'Switzerland' do
       it_splits '41443643532', ['41', '44', '364', '35', '32'] # Zurich (usually)


### PR DESCRIPTION
Hi everyone!

We are using `Phony` in our app with a great success and pleasure but we ran into some issues.
Our product is Sweden based so we have mostly Swedish numbers and not every one of them was passing validations.

The most common reason for us was that current implementation of `Phony` does not support 5 digit phone numbers for SE and according to my Swedish client they are not that uncommon - he has one as his home number himself. 

Today one of our users from Tomelilla could not validate his 5 digit number too so I decided to make a patch. I had to add Tomelilla NDCS and enable all the 5-digits.

I also asked if there is a convention used for splitting 5 digit numbers and was told the `[3, 2]` split is sometimes used. 

So here you are :)
