### PR TITLE
Add support for Finnish 029 and short mobile/switch numbers

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -634,11 +634,23 @@ Phony.define do
   #
   country '358',
           trunk('0') |
-          match(/^([1-3]0)\d+$/)          >> split(3,3,0..6) | # Service/subscriber
-          match(/^([6-8]00)\d+$/)         >> split(3,3)   | # Service
-          match(/^(457|4\d|50)\d+$/)      >> split(3,2,0..2) | # Mobile
-          one_of('2','3','5','6','8','9') >> split(3,2..4)   | # Short NDCs
-          fixed(2)                        >> split(3,3)     # 2-digit NDCs
+          match(/^(600[3-5]\d|601\d\d|700[3457]\d|7500[12]|7532[12]|7575[12]|7598[12])\d{3,4}$/) >> split(3..4) | # national service numbers, 5-digit NDC
+          match(/^(753[02][3-9]|7575[3-9]|7598[3-9])\d{3,5}$/)                                   >> split(3..5) |  # national subscriber numbers, 5-digit NDC
+          match(/^(73[0-4]\d\d)\d{5}$/)                                                          >> split(5) |     # national subscriber numbers, 5-digit NDC (starting with 073)
+          match(/^(202[023]|209[8-9]|600[0126-9]|700[0126]|7099|800\d)\d{4,5}$/) >> split(2, 2..3) | # national service numbers, 4-digit NDCs
+          match(/^(606\d|70[78]\d)\d{6}$/)                                       >> split(3, 3) |    # national service numbers, 4-digit NDCs (starting with 0606/0707/0708)
+          match(/^(202[14-9]|209[0-7])\d{4,6}$/)                                 >> split(3, 1..3) |  # national subscriber numbers, 4-digit NDCs
+          match(/^(45[45789]\d)\d{2,6}$/)                                        >> split(2, 0..4) | # mobile numbers, 4-digit NDCs
+          match(/^([123]00|602)\d{5,6}$/)                      >> split(3, 2..3) |  # national service numbers, 3-digit NDCs
+          match(/^(10[1-9]|20[13-8]|30[1-9]|73[5-9])\d{5,7}$/) >> split(3, 2..4) | # national subscriber numbers, 3-digit NDCs
+          match(/^(71\d)\d{6}$/)                               >> split(3, 3) |    # national subscriber numbers, 3-digit NDCs (starting with 071)
+          match(/^(73[5-9])\d{7}$/)                            >> split(3, 4) |    # national subscriber numbers, 3-digit NDCs (starting with 073)
+          match(/^(43\d|45[0-36])\d{5,7}$/)                    >> split(3, 2..4) |  # mobile numbers, 3-digit NDCs
+          match(/^(49\d)\d{8}$/)                               >> split(3, 3, 2) |  # mobile numbers, 3-digit NDCs (starting with 049)
+          match(/^([235]9)\d{6,8}$/)        >> split(3, 3, 0..2) | # national subscriber numbers, 2-digit NDCs
+          match(/^(4[0124678]|50)\d{4,8}$/) >> split(3, 1..5) | # mobile numbers, 2-digit NDCs
+          one_of('2','3','5','6','8','9') >> split(3,1..5)   | # Short NDCs
+          fixed(2)                        >> split(3, 0..4)    # 2-digit NDCs
 
   # Bulgaria
   #

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -64,13 +64,21 @@ describe 'plausibility' do
       it_is_correct_for 'Faroe Islands', :samples => '+298  969 597'
       it_is_correct_for 'Fiji (Republic of)', :samples => '+679  998 2441'
       it 'is correct for Finland' do
+        Phony.plausible?('+358 50 123 4').should be_true
         Phony.plausible?('+358 50 123 45').should be_true
         Phony.plausible?('+358 50 123 45 6').should be_true
         Phony.plausible?('+358 50 123 45 67').should be_true
+        Phony.plausible?('+358 50 123 45 678').should be_true
+        Phony.plausible?('+358 49 123 456 789').should be_true
+        Phony.plausible?('+358 18 1234').should be_true
+        Phony.plausible?('+358 9 1234').should be_true
         Phony.plausible?('+358 9 123 45').should be_true
         Phony.plausible?('+358 9 123 456').should be_true
         Phony.plausible?('+358 9 123 4567').should be_true
         Phony.plausible?('+358 20 1470 740').should be_true
+        Phony.plausible?('+358 29 123 4567').should be_true
+        Phony.plausible?('+358 75323 1234').should be_true
+        Phony.plausible?('+358 50 123 456 789').should be_false
       end
       it_is_correct_for 'French Guiana (French Department of)', :samples => '+594 594 123 456'
       it_is_correct_for "French Polynesia (Territoire français d'outre-mer)", :samples => '+689 87 27 84 00'

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -220,7 +220,7 @@ describe 'country descriptions' do
       it_splits '3589123123', ['358', '9', '123', '123'] # Helsinki
       it_splits '3581912312', ['358', '19', '123', '12'] # Nylandia
       it_splits '3585012312', ['358', '50', '123', '12'] # Mobile
-      it_splits '358600123',  ['358', '600', '123']      # Service
+      it_splits '35860012345',  ['358', '6001', '23', '45']      # Service
     end
     describe 'France' do
       it_splits '33112345678', ['33', '1', '12','34','56','78'] # Paris


### PR DESCRIPTION
Added more granular matching based on the Ficora regulation 32. This fixes longer 029-prefixed national subscriber numbers, very short mobile subscriber numbers from the early days of GSM, as well as short switch numbers, all of which were previously not recognized as valid. Ref issue #334 