### PR TITLE
Update Albania splitter - Mobile numbers with 7 digits after operator code

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -612,8 +612,12 @@ Phony.define do
   # country '353' # Republic of Ireland, see special file.
 
   country '354', none >> split(3,4) # Iceland
+
+  # Albania
+  #  https://en.wikipedia.org/wiki/Telephone_numbers_in_Albania
   country '355', trunk('0') |
-                 one_of('4') >> split(4,3) | # Albania
+                 one_of('4') >> split(3,4) | # Tirana
+                 match(/\A(6[6-9])\d*\z/) >> split(3,4) | # mobile
                  match(/\A(2[24]|3[2-5]|47|5[2-5]|6[6-9]|8[2-5])\d*\z/) >> split(3,3) |
                  fixed(3) >> split(3,2)
 

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -21,6 +21,12 @@ describe 'country descriptions' do
       it_splits '93201234567', ['93', '20', '1234567'] # Kabul
     end
 
+    describe 'Albania' do
+      it_splits '355691234567', ['355', '69', '123', '4567'] # Mobile 7 digits
+      it_splits '35569123456', ['355', '69', '123', '456'] # Mobile 6 digits
+      it_splits '35541234567', ['355', '4', '123', '4567'] # Tirana
+    end
+
     describe 'Algeria' do
       it_splits '213211231234', ['213', '21', '123', '1234'] # Algiers
       it_splits '213331231234', ['213', '33', '123', '1234'] # Batna


### PR DESCRIPTION
A customer was unable to validate their phone number, format '+355 69 1234 567'
At this time, I can't confirm if the previous format for mobile '+355 69 123 456' is still valid or not, so I kept that as valid.

- Separated matcher for mobile numbers /6[6-9]/ from previous matcher regex
- Added specs for mobile 6- and 7- digit and for Tirana area code