### PR TITLE
Adjust Bosnia and Herzegovina to expect 6-digit numbers, not 7

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -726,7 +726,7 @@ Phony.define do
           one_of('1','2','3','4','5','7')  >> split(3,4) | # Ljubljana, Maribor, Celje, Kranj, Nova Gorica, Novo mesto
           fixed(3)                         >> split(2,3)   # catchall
 
-  country '387', trunk('0') | fixed(2) >> split(3,2,2) # Bosnia and Herzegovina
+  country '387', trunk('0') | fixed(2) >> split(3,3) # Bosnia and Herzegovina
   country '388', trunk('0') | fixed(2) >> split(3,2,2) # Group of countries, shared code
 
   # The Former Yugoslav Republic of Macedonia

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -47,6 +47,9 @@ describe 'plausibility' do
 
     context 'specific countries' do
       it_is_correct_for 'Austria', :samples => '+43 720 116987' # VoIP
+      it_is_correct_for 'Bosnia and Herzegovina', :samples => ['+387 66 666 666',
+                                                               '+387 37 123 456',
+                                                               '+387 33 222 111']
       it_is_correct_for 'Congo', :samples => '+242 1234 56789'
       it_is_correct_for 'Cook Islands', :samples => '+682  71928'
       it_is_correct_for 'Costa Rica', :samples => '+506 2 234 5678'

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -128,6 +128,11 @@ describe 'country descriptions' do
       it_splits '26781234567', %w(267 8 1234 567)
     end
 
+    describe 'Bosnia and Herzegovina' do
+      it_splits '38766666666', %w(387 66 666 666)
+      it_splits '38733123456', %w(387 33 123 456)
+    end
+
     describe 'Brazil' do
       it_splits '551112341234', ['55', '11', '1234', '1234']
       it_splits '5511981231234', ['55', '11', '98123', '1234'] # São Paulo's 9 digits mobile


### PR DESCRIPTION
In response to #342

Since I don't really know anything about how phone numbers in Bosnia and Herzegovina are formatted, I've looked up some companies and pulled their contact numbers, stuck them into the `plausibility_spec.rb` and `countries_spec.rb` and then found none to work. (Note that I've anonymised these numbers into simple sequences, not sure if real numbers in the specs are considered a problem...)

From what I've come up across while looking into this I think the numbers should be in the form of leading 0, 2-digit area code, 6-digit number, so I think the `countries.rb` definition simply had the wrong length implied by the previous split.

