### PR TITLE
663 Austrian mobile number can be more than 6 digits.

### DIFF
--- a/lib/phony/countries/austria.rb
+++ b/lib/phony/countries/austria.rb
@@ -39,6 +39,7 @@ mobile = [
  '659',
  '660',
  '661',
+ '663',
  '664',
  '665',
  '666',
@@ -95,7 +96,6 @@ Phony.define do
                 one_of(corporate_2digit) >> split(3..11)  | # Corporate number length is 5..13
                 one_of(corporate)        >> split(2..10)  | # Corporate number length is 5..13
                 one_of(ndcs)             >> split(6..10)  |
-                one_of('663')            >> split(6..6)   | # 6 digit mobile.
                 one_of(mobile)           >> split(4,3..9) |
                 one_of(mobile_2digit)    >> split(7..7)   | # Separate as mobile contains 676 - 67 violates the prefix rule.
                 fixed(4)                 >> split(3..9)     # Number length is 7..13.

--- a/lib/phony/countries/austria.rb
+++ b/lib/phony/countries/austria.rb
@@ -39,7 +39,6 @@ mobile = [
  '659',
  '660',
  '661',
- '663',
  '664',
  '665',
  '666',
@@ -96,6 +95,7 @@ Phony.define do
                 one_of(corporate_2digit) >> split(3..11)  | # Corporate number length is 5..13
                 one_of(corporate)        >> split(2..10)  | # Corporate number length is 5..13
                 one_of(ndcs)             >> split(6..10)  |
+                one_of('663')            >> split(6..8)   | # 6..8 digit mobile.
                 one_of(mobile)           >> split(4,3..9) |
                 one_of(mobile_2digit)    >> split(7..7)   | # Separate as mobile contains 676 - 67 violates the prefix rule.
                 fixed(4)                 >> split(3..9)     # Number length is 7..13.

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -93,9 +93,13 @@ Mobile.
     Phony.assert.plausible?('+43 688 0000000')
     Phony.assert.plausible?('+43 699 00000000')
 
+663 mobile numbers have 6..8 digits.
+
+    Phony.assert.plausible?('+43 663 000000')
+    Phony.assert.plausible?('+43 663 1234 5678')
+
 Mobile numbers can have from 7 to 10 digits in the subscriber number.
 
-    Phony.assert.plausible?('+43 663 1234 567890')
     Phony.assert.plausible?('+43 664 1234 567')
     Phony.assert.plausible?('+43 664 1234 5678')
     Phony.assert.plausible?('+43 664 1234 56789')

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -96,7 +96,7 @@ Mobile.
 663 mobile numbers have 6..8 digits.
 
     Phony.assert.plausible?('+43 663 000000')
-    Phony.assert.plausible?('+43 663 1234 5678')
+    Phony.assert.plausible?('+43 663 12345678')
 
 Mobile numbers can have from 7 to 10 digits in the subscriber number.
 

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -93,12 +93,9 @@ Mobile.
     Phony.assert.plausible?('+43 688 0000000')
     Phony.assert.plausible?('+43 699 00000000')
 
-663 mobile numbers have 6 digits.
-
-    Phony.assert.plausible?('+43 663 000000')
-
 Mobile numbers can have from 7 to 10 digits in the subscriber number.
 
+    Phony.assert.plausible?('+43 663 1234 567890')
     Phony.assert.plausible?('+43 664 1234 567')
     Phony.assert.plausible?('+43 664 1234 5678')
     Phony.assert.plausible?('+43 664 1234 56789')

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -51,7 +51,6 @@ describe 'country descriptions' do
       it_splits '436880000000',    %w( 43 688 0000 000 )   # Mobile
       it_splits '4366900000000',   %w( 43 669 0000 0000 )  # Mobile
       it_splits '4367000000000',   %w( 43 670 0000 0000 )  # Mobile
-      it_splits '4366300000000',   %w( 43 663 0000 0000 )  # Mobile
       it_splits '433161234567891', %w( 43 316 1234567891 ) # Graz
       it_splits '432164123456789', %w( 43 2164 123456789 ) # Rohrau
       it_splits '43720116987',     %w( 43 720 116987 )     # VoIP

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -51,6 +51,7 @@ describe 'country descriptions' do
       it_splits '436880000000',    %w( 43 688 0000 000 )   # Mobile
       it_splits '4366900000000',   %w( 43 669 0000 0000 )  # Mobile
       it_splits '4367000000000',   %w( 43 670 0000 0000 )  # Mobile
+      it_splits '4366300000000',   %w( 43 663 0000 0000 )  # Mobile
       it_splits '433161234567891', %w( 43 316 1234567891 ) # Graz
       it_splits '432164123456789', %w( 43 2164 123456789 ) # Rohrau
       it_splits '43720116987',     %w( 43 720 116987 )     # VoIP


### PR DESCRIPTION
We have a customer who confirmed that number `+43663060377xx` is correct Austrian mobile number. 

@floere do you remember anything about that `663 mobile numbers have 6 digits.` rule? Couldn't find anything on the internet.