### PR TITLE
Fixes Hungarian phone number format

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -122,11 +122,19 @@ Phony.define do
 
   # Hungary.
   #
+  # http://webpub-ext.nmhh.hu/aga/foldr/DoIndexAction.do
+  #
   country '36',
     trunk('06', normalize: false) |
-    one_of('104','105','107','112') >> split(3,3) | # Service
-    one_of('1')                     >> split(3,4) | # Budapest
-    fixed(2)                        >> split(3,4)   # 2-digit NDCs
+    one_of('104', '105', '107', '112')   >> split(3,3) | # Service
+    one_of('1')                          >> split(3,4) | # Budapest
+    one_of('20', '30', '31', '50', '70') >> split(3,4) | # Mobile
+    one_of('21')                         >> split(3,4) | # VOIP
+    one_of('40', '80', '90', '91')       >> split(3,3) | # Special charged numbers
+    one_of('51')                         >> split(3,3) | # Corporate network, M2M
+    one_of('38')                         >> split(3,4) | # Corporate network, M2M
+    one_of('71')                         >> split(5,5) | # M2M Numbers
+    fixed(2)                             >> split(3,3)   # Geographic numbers
 
   # country '39' # Italy, see special file.
 

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -488,6 +488,25 @@ Mobile.
       '+30 909 123 4565'
     ]
 
+#### Hungary
+
+    plausible? true: [
+        '+36 1 234 5678',     # Budapest
+        '+36 20 1234 567',    # Telenor
+        '+36 30 1234 567',    # T-Mobile
+        '+36 70 1234 567',    # Vodafone
+        '+36 31 1234 567',    # UPC, Tesco Mobile
+        '+36 21 1234 567',    # Voip
+        '+36 40 123 456',     # Business rate numbers
+        '+36 80 123 456',     # Freephone service
+        '+36 90 123 456',     # Premium-rate number
+        '+36 91 123 456',     # Premium-rate number
+        '+36 38 123 4567',    # Corporate network numbers
+        '+36 51 123 456',     # SHS
+        '+36 71 12345 67890', # M2M (2+10)
+        '+36 22 123 567'      # Geographic number
+    ]
+
 #### Indonesia
 
     plausible? true: [


### PR DESCRIPTION
There are issues with Hungarian geographic phone numbers (2+6), because phony wants to parse them as 2+7. In Hungary every phone number goes with 2 digits area code which is not a local number of Budapest and the length of these number varies. National geographic numbers includes 2+6 digits, mobile and voip numbers are 2+7 length and there is a special business number with 2+10 format.

I added an example for each type of phone number in the plausibility.md file.

The source of these phone number formats is the Hungarian Media and Info-communication Authority: http://webpub-ext.nmhh.hu/aga/foldr/DoIndexAction.do