### PR TITLE
FIX Italian 2ndcs

### DIFF
--- a/lib/phony/countries/italy.rb
+++ b/lib/phony/countries/italy.rb
@@ -267,7 +267,7 @@ Phony.define do
   country '39', trunk('', :normalize => false) |
                 one_of(*service)     >> split(3,3) |
                 one_of(*mobile)      >> split(3,4,-1..1) |
-                one_of(*ndcs_2digit) >> split(4,4) |
+                one_of(*ndcs_2digit) >> split(4, 2..4) |
                 one_of(*ndcs_3digit) >> matched_split(
                   /^1\d{6}$/ => [7],
                   /^1\d{7}$/ => [8],

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -527,6 +527,8 @@ Mobile.
 
 #### Italy
 
+    Phony.assert.plausible?('+39 06 1234 45')
+    Phony.assert.plausible?('+39 06 1234 456')
     Phony.assert.plausible?('+39 06 1234 4567')
 
     Phony.refute.plausible?('+39 035 00000')

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -405,8 +405,12 @@ describe 'country descriptions' do
       it_splits '3934869528123',['39', '348', '695', '2812', '3']  # Mobile (8-digit subscriber no - new)
       it_splits '393357210488', ['39', '335', '721', '0488'] # Mobile
       it_splits '393248644272', ['39', '324', '864', '4272'] # Mobile
-      it_splits '390612341234', ['39', '06', '1234', '1234'] # Roma
-      it_splits '390288838883', ['39', '02', '8883', '8883'] # Milano
+      it_splits '3906123412',   ['39', '06', '1234', '12'] # Roma 6 digit
+      it_splits '39061234123',  ['39', '06', '1234', '123'] # Roma 7 digit
+      it_splits '390612341234', ['39', '06', '1234', '1234'] # Roma 8 digit
+      it_splits '3902888388',   ['39', '02', '8883', '88'] # Milano 6 digit
+      it_splits '39028883888',  ['39', '02', '8883', '888'] # Milano 7 digit
+      it_splits '390288838883', ['39', '02', '8883', '8883'] # Milano 8 digit
       it_splits '390141595661', ['39', '0141', '595', '661'] # Asti
       it_splits '3903123391',   ['39', '031', '23391']   # Como
       it_splits '390909709511', ['39', '090', '9709511'] # Barcellona


### PR DESCRIPTION
Fix incorrect constraint of Rome and Milan phone numbers to always be 8 digits.

Some examples of 6 and 7 digit Rome and Milan numbers:

Hotel Lancaster: `+39 02 344705`
Enterprise Hotel: `+39 02 318181`
Radisson Blu Hotel Milan: `+39 02 363 1888`

UNA Hotel Roma: `+39 06 649371`
Radisson Blu es. Hotel, Rome: `+39 06 444841`
Nerva Boutique Hotel: `+39 06 678 1835`