### PR TITLE
Adds support for missing polish mobile numbers (starting with 45 and 57)

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -178,7 +178,7 @@ Phony.define do
   # Note: http://wapedia.mobi/en/Telephone_numbers_in_Poland, mobile not yet correct
   #
   country '48',
-          match(/^(5[013]\d|6[069]\d|7[02389]\d|80[01]|88\d)/) >> split(3,3) |
+          match(/^(45\d|5[0137]\d|6[069]\d|7[02389]\d|80[01]|88\d)/) >> split(3,3) |
           fixed(2)                                             >> split(3,2,2)
 
   # country '49' # Germany, see special file.

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -569,6 +569,8 @@ describe 'country descriptions' do
     describe 'Poland' do
       it_splits '48123456789', ['48', '12', '345', '67', '89'] # Landline
       it_splits '48501123456', ['48', '501', '123', '456']     # Mobile
+      it_splits '48571123456', ['48', '571', '123', '456']     # Mobile
+      it_splits '48451123456', ['48', '451', '123', '456']     # Mobile
       it_splits '48800123456', ['48', '800', '123', '456']     # Free
       it_splits '48801123456', ['48', '801', '123', '456']     # Shared cost
       it_splits '48701123456', ['48', '701', '123', '456']     # Premium


### PR DESCRIPTION
Some polish mobile numbers were formatted incorrectly. 
I updated formating rules to reflect current list of valid polish mobile numbers (see eg https://en.wikipedia.org/wiki/Telephone_numbers_in_Poland)