### PR TITLE
Update Congo normalization to handle a trunk zero in mobile numbers

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -401,7 +401,9 @@ Phony.define do
 
   country '240', none >> split(3,3,3) # Equatorial Guinea
   country '241', fixed(1) >> split(3,3) # Gabonese Republic http://www.wtng.info/wtng-241-ga.html
-  country '242', none >> split(4,5) # Congo http://www.wtng.info/wtng-242-cg.html
+  country '242', # Congo http://www.wtng.info/wtng-242-cg.html
+    trunk('', :normalize => false) |
+    none >> split(4,5)
   country '243', fixed(2) >> split(3,4) # Democratic Republic of the Congo http://www.wtng.info/wtng-243-cd.html
   country '244', one_of('321', '348', '358', '363', '364', '485', '526', '535', '546', '612', '643', '652', '655', '722', '726', '728', '729', '777') >> split(3,3) | # Angola
                  fixed(2) >> split(3,4)

--- a/spec/lib/phony/country_codes_spec.rb
+++ b/spec/lib/phony/country_codes_spec.rb
@@ -48,6 +48,13 @@ describe Phony::CountryCodes do
     it 'normalizes correctly with CC option' do
       @countries.normalize('044-364-35-32', cc: '41').should eql '41443643532'
     end
+
+    context 'specific countries' do
+      it 'handles Congo correctly' do
+        @countries.normalize('+242 0571 73992').should eql '242057173992'
+        @countries.normalize('+242 2221 15932').should eql '242222115932'
+      end
+    end
   end
 
   describe 'formatted' do


### PR DESCRIPTION
@floere: Addresses https://github.com/floere/phony/issues/364

Mobile numbers for the Congo were not being normalized correctly - this handles the trunk zero.