### PR TITLE
Update croatia zambia phone formats

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -472,9 +472,11 @@ Phony.define do
 
   # Zambia
   # http://www.wtng.info/wtng-260-zm.html
+  # https://github.com/googlei18n/libphonenumber/
   country '260',
-    match(/^(9(55|66|7[7-9]))/) >> split(6) | # mobile
-    match(/^(21[1-8])/) >> split(6) # fixed
+    match(/^(9(5[034589]|[67]\d))/) >> split(6)   | # Mobile
+    match(/^(800)/)                 >> split(3,3) | # Toll free
+    match(/^(21[1-8])/)             >> split(6)     # Fixed
 
   # Madagascar http://www.wtng.info/wtng-261-mg.html
   # http://www.itu.int/oth/T020200007F/en

--- a/lib/phony/countries/croatia.rb
+++ b/lib/phony/countries/croatia.rb
@@ -3,24 +3,19 @@
 # http://en.wikipedia.org/wiki/Telephone_numbers_in_Croatia
 # http://dialcode.org/Europe/Croatia/
 # http://www.howtocallabroad.com/croatia/
-#
-# Landline numbers are composed by a 2 digits area code + 6 fixed digits 
-# Mobile numbers are composed by a 2 digits prefix + 7 fixed digits 
+# https://github.com/googlei18n/libphonenumber/
 #
 
-mobile = %w(
-  91
-  92
-  95
-  97
-  977
-  98
-  99
-)
+landline = /^(2[0-3]|3[1-5]|4[02-47-9]|5[1-3])/
 
 Phony.define do
   country '385', trunk('0') |
-                 one_of(mobile) >> split(3, 4) |
-                 one_of('1')    >> split(4, 3) | # Zagreb
-                 fixed(2)       >> split(3, 3)   # 2-digit NDCs
+                 one_of('1')         >> split(4, 3)       | # Zagreb
+                 match(/^(80[01])/)  >> matched_split(
+                                    /\A\d{4}\z/ => [4],
+                                    /\A\d{6}\z/ => [3,3]) | # Toll free
+                 match(/^(9\d)/)     >> split(3, 3..4)    | # Mobile
+                 match(landline)     >> split(3, 3..4)    | # Landline
+                 match(/^(6[01])/)   >> split(2,2..3)     | # Premium rate
+                 match(/^([67]\d)/)  >> split(3,3..4)       # Premium, personal and UAN
 end

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -53,6 +53,16 @@ describe 'plausibility' do
       it_is_correct_for 'Congo', :samples => '+242 1234 56789'
       it_is_correct_for 'Cook Islands', :samples => '+682  71928'
       it_is_correct_for 'Costa Rica', :samples => '+506 2 234 5678'
+      it 'is correct for Croatia' do
+          Phony.plausible?('+385 21 695 900').should be_true  # Landline
+          Phony.plausible?('+385 1 4566 666').should be_true  # Landline (Zagreb)
+          Phony.plausible?('+385 99 444 999').should be_true  # Mobile
+          Phony.plausible?('+385 91 896 7509').should be_true # Mobile
+          Phony.plausible?('+385 800 1234').should be_true    # Toll free
+          Phony.plausible?('+385 800 123 456').should be_true # Toll free
+          Phony.plausible?('+385 60 12 345').should be_true   # Premium rate
+          Phony.plausible?('+385 62 123 456').should be_true  # Premium, personal and UAN
+      end
       it_is_correct_for "Côte d'Ivoire", :samples => '+225  9358 8764'
       it_is_correct_for 'Democratic Republic of Timor-Leste', :samples => ['+670 465 7886', '+670 7465 7886']
       it_is_correct_for 'Democratic Republic of the Congo', :samples => '+243 80 864 9794'

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -372,8 +372,11 @@ describe 'plausibility' do
                                               '+967 77 123 4567',
                                               '+967 58 1234']
       it 'is correct for Zambia' do
-        Phony.plausible?('+260 955 123456').should be_true # mobile
-        Phony.plausible?('+260 211 123456').should be_true # fixed
+        Phony.plausible?('+260 211 123456').should be_true  # Fixed
+        Phony.plausible?('+260 955 123456').should be_true  # Mobile
+        Phony.plausible?('+260 967 123456').should be_true  # Mobile
+        Phony.plausible?('+260 978 123456').should be_true  # Mobile
+        Phony.plausible?('+260 800 123 456').should be_true # Toll free
       end
       it_is_correct_for 'Zimbabwe', :samples => [['+263 2582 123 456', '+263 2582 123'],
                                                  ['+263 147 123 456', '+263 147 123'],

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -201,7 +201,12 @@ describe 'country descriptions' do
     describe 'Croatia' do
       it_splits '38521695900',  %w( 385 21 695 900 )  # Landline
       it_splits '38514566666',  %w( 385 1 4566 666 )  # Landline (Zagreb)
+      it_splits '38599444999',  %w( 385 99 444 999 )  # Mobile
       it_splits '385918967509', %w( 385 91 896 7509 ) # Mobile
+      it_splits '3858001234',   %w( 385 800 1234 )    # Toll free
+      it_splits '385800123456', %w( 385 800 123 456 ) # Toll free
+      it_splits '3856012345',   %w( 385 60 12 345 )   # Premium rate
+      it_splits '38562123456',  %w( 385 62 123 456 )  # Premium, personal and UAN
     end
     describe 'Cuba' do
       it_splits '5351231234', ['53', '5123', '1234'] # Mobile

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -782,8 +782,11 @@ describe 'country descriptions' do
       it_splits '84412345678', ['84', '4', '1234', '5678'] # Hanoi
     end
     describe 'Zambia' do
-      it_splits '260955123456', ['260', '955', '123456'] # mobile
-      it_splits '260211123456', ['260', '211', '123456'] # fixed
+      it_splits '260211123456', ['260', '211', '123456']     # Fixed
+      it_splits '260955123456', ['260', '955', '123456']     # Mobile
+      it_splits '260967123456', ['260', '967', '123456']     # Mobile
+      it_splits '260978123456', ['260', '978', '123456']     # Mobile
+      it_splits '260800123456', ['260', '800', '123', '456'] # Toll free
     end
     describe 'New Zealand' do
       it_splits '6491234567', ['64', '9', '123', '4567']


### PR DESCRIPTION
This pull request updates mobile, landline and special phone number formats for Croatia and Zambia , it is based on the information from
https://github.com/googlei18n/libphonenumber/blob/master/resources/PhoneNumberMetadata.xml