### PR TITLE
Add other landline prefix for Macao

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -986,7 +986,8 @@ Phony.define do
   # Macao, China
   country '853', # Macao, China
     match(/^(28)\d+$/) >> split(2,4) | # Landline.
-    match(/^(6)\d+$/)  >> split(3,4)  # Mobile.
+    match(/^(8)\d+$/)  >> split(3,4) | # Landline.
+    match(/^(6)\d+$/)  >> split(3,4)   # Mobile.
 
   country '854', todo # Spare code
 

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -171,6 +171,9 @@ describe 'plausibility' do
         Phony.plausible?('+231 4 123 456').should be_true
         Phony.plausible?('+231 77 123 4567').should be_true
       end
+      it_is_correct_for 'Macao', :samples => ['+853 28 12 3456',
+                                              '+853 8 123 4567',
+                                              '+853 6 123 4567',]
       it_is_correct_for 'Macedonia', :samples => ['+389 2 123 4567',
                                                    '+389 7 124 3456',
                                                    '+389 7 234 5678']

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -474,6 +474,7 @@ describe 'country descriptions' do
     end
     describe 'Macao' do
       it_splits '85328123456', ["853", "28", "12", "3456"] # Landline
+      it_splits '85381234567', ["853", "8", "123", "4567"] # Landline
       it_splits '85361234567', ["853", "6", "123", "4567"] # Mobile
     end
     describe 'Malaysia' do


### PR DESCRIPTION
Another landline prefix exist for Macao number.
Here I added the prefix `8` along with the existing one `28`

See [Numbering scheme and format](https://en.wikipedia.org/wiki/Telephone_numbers_in_Macau)
You also can confirm this in the [yellow pages](http://en.yp.mo/search.html?keyword=8).

I'm not really sure what the difference is though ...