### PR TITLE
Upgrade rspec: 2.14.1 -> 3.6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'coveralls', require: false
 group :test do
   gem 'qed'
   gem 'ae'
-  gem 'rspec', '~> 2.0'
+  gem 'rspec'
   gem 'pippi', platforms: [:mri_20, :mri_21]
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     docile (1.1.1)
     ffi2-generators (0.1.1)
     json (1.8.1)
@@ -24,14 +24,19 @@ GEM
     rake (10.1.1)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.7)
-    rspec-expectations (2.14.4)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.4)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
     rubinius-coverage (2.0.3)
     rubinius-debugger (2.0.0)
     rubinius-developer_tools (2.0.0)
@@ -261,6 +266,9 @@ DEPENDENCIES
   pippi
   qed
   rake
-  rspec (~> 2.0)
+  rspec
   rubinius-developer_tools
   rubysl (~> 2.0)
+
+BUNDLED WITH
+   1.15.1

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -25,11 +25,11 @@ describe 'plausibility' do
           incorrect = [shortest.sub(/\d\s*\z/, '')] # , longest + '0']
 
           correct.each do |value|
-            Phony.plausible?(value).should be_true,
+            Phony.plausible?(value).should eq(true),
               "It should validate #{value}, but does not."
           end
           incorrect.each do |value|
-            Phony.plausible?(value).should be_false,
+            Phony.plausible?(value).should eq(false),
               "It should not validate #{value}, but does."
           end
         end
@@ -38,7 +38,7 @@ describe 'plausibility' do
           invalid = [*sample]
 
           invalid.each do |value|
-            Phony.plausible?(value).should be_false,
+            Phony.plausible?(value).should eq(false),
               "It should not validate #{value}, but does."
           end
         end
@@ -54,14 +54,14 @@ describe 'plausibility' do
       it_is_correct_for 'Cook Islands', :samples => '+682  71928'
       it_is_correct_for 'Costa Rica', :samples => '+506 2 234 5678'
       it 'is correct for Croatia' do
-          Phony.plausible?('+385 21 695 900').should be_true  # Landline
-          Phony.plausible?('+385 1 4566 666').should be_true  # Landline (Zagreb)
-          Phony.plausible?('+385 99 444 999').should be_true  # Mobile
-          Phony.plausible?('+385 91 896 7509').should be_true # Mobile
-          Phony.plausible?('+385 800 1234').should be_true    # Toll free
-          Phony.plausible?('+385 800 123 456').should be_true # Toll free
-          Phony.plausible?('+385 60 12 345').should be_true   # Premium rate
-          Phony.plausible?('+385 62 123 456').should be_true  # Premium, personal and UAN
+          Phony.plausible?('+385 21 695 900').should eq(true)  # Landline
+          Phony.plausible?('+385 1 4566 666').should eq(true)  # Landline (Zagreb)
+          Phony.plausible?('+385 99 444 999').should eq(true)  # Mobile
+          Phony.plausible?('+385 91 896 7509').should eq(true) # Mobile
+          Phony.plausible?('+385 800 1234').should eq(true)    # Toll free
+          Phony.plausible?('+385 800 123 456').should eq(true) # Toll free
+          Phony.plausible?('+385 60 12 345').should eq(true)   # Premium rate
+          Phony.plausible?('+385 62 123 456').should eq(true)  # Premium, personal and UAN
       end
       it_is_correct_for "Côte d'Ivoire", :samples => '+225  9358 8764'
       it_is_correct_for 'Democratic Republic of Timor-Leste', :samples => ['+670 465 7886', '+670 7465 7886']
@@ -69,30 +69,30 @@ describe 'plausibility' do
       it_is_correct_for 'Diego Garcia', :samples => '+246  123 7686'
       it_is_correct_for 'Djibouti', :samples => '+253  3671 1431'
       it 'is correct for Ecuador' do
-        Phony.plausible?('+593 22 000 0000').should be_true
-        Phony.plausible?('+593 23 000 0000').should be_true
-        Phony.plausible?('+593 26 000 0000').should be_true
-        Phony.plausible?('+593 27 000 0000').should be_true
-        Phony.plausible?('+593 44 000 0000').should be_true
-        Phony.plausible?('+593 45 000 0000').should be_true
-        Phony.plausible?('+593 47 000 0000').should be_true
-        Phony.plausible?('+593 2 200 0000').should be_true
-        Phony.plausible?('+593 2 300 0000').should be_true
-        Phony.plausible?('+593 2 400 0000').should be_true
-        Phony.plausible?('+593 2 500 0000').should be_true
-        Phony.plausible?('+593 2 700 0000').should be_true
-        Phony.plausible?('+593 3 000 0000').should be_true
-        Phony.plausible?('+593 4 000 0000').should be_true
-        Phony.plausible?('+593 4 500 0000').should be_true
-        Phony.plausible?('+593 4 600 0000').should be_true
-        Phony.plausible?('+593 5 200 0000').should be_true
-        Phony.plausible?('+593 5 300 0000').should be_true
-        Phony.plausible?('+593 6 200 0000').should be_true
-        Phony.plausible?('+593 7 200 0000').should be_true
-        Phony.plausible?('+593 7 300 0000').should be_true
-        Phony.plausible?('+593 7 400 0000').should be_true
-        Phony.plausible?('+593 7 600 0000').should be_true
-        Phony.plausible?('+593 9 0000 0000').should be_true # mobile
+        Phony.plausible?('+593 22 000 0000').should eq(true)
+        Phony.plausible?('+593 23 000 0000').should eq(true)
+        Phony.plausible?('+593 26 000 0000').should eq(true)
+        Phony.plausible?('+593 27 000 0000').should eq(true)
+        Phony.plausible?('+593 44 000 0000').should eq(true)
+        Phony.plausible?('+593 45 000 0000').should eq(true)
+        Phony.plausible?('+593 47 000 0000').should eq(true)
+        Phony.plausible?('+593 2 200 0000').should eq(true)
+        Phony.plausible?('+593 2 300 0000').should eq(true)
+        Phony.plausible?('+593 2 400 0000').should eq(true)
+        Phony.plausible?('+593 2 500 0000').should eq(true)
+        Phony.plausible?('+593 2 700 0000').should eq(true)
+        Phony.plausible?('+593 3 000 0000').should eq(true)
+        Phony.plausible?('+593 4 000 0000').should eq(true)
+        Phony.plausible?('+593 4 500 0000').should eq(true)
+        Phony.plausible?('+593 4 600 0000').should eq(true)
+        Phony.plausible?('+593 5 200 0000').should eq(true)
+        Phony.plausible?('+593 5 300 0000').should eq(true)
+        Phony.plausible?('+593 6 200 0000').should eq(true)
+        Phony.plausible?('+593 7 200 0000').should eq(true)
+        Phony.plausible?('+593 7 300 0000').should eq(true)
+        Phony.plausible?('+593 7 400 0000').should eq(true)
+        Phony.plausible?('+593 7 600 0000').should eq(true)
+        Phony.plausible?('+593 9 0000 0000').should eq(true) # mobile
       end
       it_is_correct_for 'Equatorial Guinea', :samples => ['+240 222 201 123',
                                                           '+240 335 201 123']
@@ -102,21 +102,21 @@ describe 'plausibility' do
       it_is_correct_for 'Faroe Islands', :samples => '+298  969 597'
       it_is_correct_for 'Fiji (Republic of)', :samples => '+679  998 2441'
       it 'is correct for Finland' do
-        Phony.plausible?('+358 50 123 4').should be_true
-        Phony.plausible?('+358 50 123 45').should be_true
-        Phony.plausible?('+358 50 123 45 6').should be_true
-        Phony.plausible?('+358 50 123 45 67').should be_true
-        Phony.plausible?('+358 50 123 45 678').should be_true
-        Phony.plausible?('+358 49 123 456 789').should be_true
-        Phony.plausible?('+358 18 1234').should be_true
-        Phony.plausible?('+358 9 1234').should be_true
-        Phony.plausible?('+358 9 123 45').should be_true
-        Phony.plausible?('+358 9 123 456').should be_true
-        Phony.plausible?('+358 9 123 4567').should be_true
-        Phony.plausible?('+358 20 1470 740').should be_true
-        Phony.plausible?('+358 29 123 4567').should be_true
-        Phony.plausible?('+358 75323 1234').should be_true
-        Phony.plausible?('+358 50 123 456 789').should be_false
+        Phony.plausible?('+358 50 123 4').should eq(true)
+        Phony.plausible?('+358 50 123 45').should eq(true)
+        Phony.plausible?('+358 50 123 45 6').should eq(true)
+        Phony.plausible?('+358 50 123 45 67').should eq(true)
+        Phony.plausible?('+358 50 123 45 678').should eq(true)
+        Phony.plausible?('+358 49 123 456 789').should eq(true)
+        Phony.plausible?('+358 18 1234').should eq(true)
+        Phony.plausible?('+358 9 1234').should eq(true)
+        Phony.plausible?('+358 9 123 45').should eq(true)
+        Phony.plausible?('+358 9 123 456').should eq(true)
+        Phony.plausible?('+358 9 123 4567').should eq(true)
+        Phony.plausible?('+358 20 1470 740').should eq(true)
+        Phony.plausible?('+358 29 123 4567').should eq(true)
+        Phony.plausible?('+358 75323 1234').should eq(true)
+        Phony.plausible?('+358 50 123 456 789').should eq(false)
       end
       it_is_correct_for 'French Guiana (French Department of)', :samples => '+594 594 123 456'
       it_is_correct_for "French Polynesia (Territoire français d'outre-mer)", :samples => '+689 87 27 84 00'
@@ -177,9 +177,9 @@ describe 'plausibility' do
                                                 '+961 81 123 456']
       it_is_correct_for 'Lesotho', :samples => '+266  7612 6866'
       it 'is correct for Liberia' do
-        Phony.plausible?('+231 2 123 4567').should be_true
-        Phony.plausible?('+231 4 123 456').should be_true
-        Phony.plausible?('+231 77 123 4567').should be_true
+        Phony.plausible?('+231 2 123 4567').should eq(true)
+        Phony.plausible?('+231 4 123 456').should eq(true)
+        Phony.plausible?('+231 77 123 4567').should eq(true)
       end
       it_is_correct_for 'Macao', :samples => ['+853 28 12 3456',
                                               '+853 8 123 4567',
@@ -372,11 +372,11 @@ describe 'plausibility' do
                                               '+967 77 123 4567',
                                               '+967 58 1234']
       it 'is correct for Zambia' do
-        Phony.plausible?('+260 211 123456').should be_true  # Fixed
-        Phony.plausible?('+260 955 123456').should be_true  # Mobile
-        Phony.plausible?('+260 967 123456').should be_true  # Mobile
-        Phony.plausible?('+260 978 123456').should be_true  # Mobile
-        Phony.plausible?('+260 800 123 456').should be_true # Toll free
+        Phony.plausible?('+260 211 123456').should eq(true)  # Fixed
+        Phony.plausible?('+260 955 123456').should eq(true)  # Mobile
+        Phony.plausible?('+260 967 123456').should eq(true)  # Mobile
+        Phony.plausible?('+260 978 123456').should eq(true)  # Mobile
+        Phony.plausible?('+260 800 123 456').should eq(true) # Toll free
       end
       it_is_correct_for 'Zimbabwe', :samples => [['+263 2582 123 456', '+263 2582 123'],
                                                  ['+263 147 123 456', '+263 147 123'],
@@ -384,15 +384,15 @@ describe 'plausibility' do
                                                  '+263 86 1235 4567']
 
       it 'is correct for Indonesia' do
-        Phony.plausible?('+62 22 000 0').should be_false
-        Phony.plausible?('+62 22 000 00').should be_true
-        Phony.plausible?('+62 22 000 0000').should be_true
-        Phony.plausible?('+62 22 0000 0000').should be_true
-        Phony.plausible?('+62 22 000 000 000').should be_true
+        Phony.plausible?('+62 22 000 0').should eq(false)
+        Phony.plausible?('+62 22 000 00').should eq(true)
+        Phony.plausible?('+62 22 000 0000').should eq(true)
+        Phony.plausible?('+62 22 0000 0000').should eq(true)
+        Phony.plausible?('+62 22 000 000 000').should eq(true)
       end
 
       it 'is correct for Russia' do
-        Phony.plausible?('+7 3522 000 000').should be_true
+        Phony.plausible?('+7 3522 000 000').should eq(true)
       end
     end
   end

--- a/spec/lib/phony/local_splitters/regex_spec.rb
+++ b/spec/lib/phony/local_splitters/regex_spec.rb
@@ -53,35 +53,35 @@ describe Phony::LocalSplitters::Regex do
     context 'Local splitter without mappings' do
       let(:local_splitter) { described_class.instance_for({})}
       it 'returns false' do
-        result.should be_false
+        result.should eq(false)
       end
     end
 
     context 'Mapping does not exist for a number' do
       let(:local_splitter) { described_class.instance_for(/\A5/ => [1,2,3])}
       it 'returns false' do
-        result.should be_false
+        result.should eq(false)
       end
     end
 
     context "Mapping exists, but the length is greater" do
       let(:local_splitter) { described_class.instance_for(/\A123/ => [2,2])}
       it 'returns false' do
-        result.should be_false
+        result.should eq(false)
       end
     end
 
     context "Mapping exists, but the length is less" do
       let(:local_splitter) { described_class.instance_for(/\A123/ => [2,2,3])}
       it 'returns false' do
-        result.should be_false
+        result.should eq(false)
       end
     end
 
     context 'Mapping exists and the length is equal' do
       let(:local_splitter) { described_class.instance_for(/\A123/ => [2,2,2])}
       it 'returns true' do
-        result.should be_true
+        result.should eq(true)
       end
     end
 

--- a/spec/lib/phony/national_splitters/default_spec.rb
+++ b/spec/lib/phony/national_splitters/default_spec.rb
@@ -19,7 +19,7 @@ describe Phony::NationalSplitters::Default do
     
     describe 'plausible?' do
       it 'is always plausible' do
-        splitter.plausible?(:anything, :anything).should be_true
+        splitter.plausible?(:anything, :anything).should eq(true)
       end
     end
     


### PR DESCRIPTION
Otherwise I was getting an error message when running `rake`:

> NoMethodError: undefined method `last_comment'

As pointed in a stack overflow post, upgrading rspec fixes it: https://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11