### PR TITLE
Fix bug with Cellcard numbers starting with +855129

### DIFF
--- a/lib/phony/countries/cambodia.rb
+++ b/lib/phony/countries/cambodia.rb
@@ -125,7 +125,7 @@ seven_digit_total_double_digit_fixed_line_prefixes = [
 Phony.define do
   country '855', trunk('0', :normalize => true) |
                  one_of(mobile_prefixes_with_variable_length) >> matched_split(/^9/ => [3, 4], /^[2-8]/ => [3, 3]) |
-                 one_of(variable_length_extended_range_mobile_prefixes) >> matched_split(/^1/ => [3, 4], /^[2-8]/ => [3, 3]) |
+                 one_of(variable_length_extended_range_mobile_prefixes) >> matched_split(/^1/ => [3, 4], /^[2-9]/ => [3, 3]) |
                  one_of(six_digit_mobile_prefixes)   >> matched_split(/^[2-9]/ => [3, 3]) |
                  one_of(six_digit_extended_range_mobile_prefixes) >> matched_split(/^[1-9]/ => [3, 3]) |
                  one_of(seven_digit_mobile_prefixes) >> matched_split(/^[2-9]/ => [3, 4]) |

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -225,6 +225,7 @@ http://www.khmerdigitalpost.com/mobile-operators-in-cambodia-by-2015/
     Phony.assert.plausible?("+855762345678")    # Mobitel (7 digit id)
     Phony.refute.plausible?("+85576234567")     # Mobitel (too short)
     Phony.assert.plausible?("+85517234567")     # Mobitel (6 digit id)
+    Phony.assert.plausible?("+85512999399")     # Mobitel (6 digit id)
     Phony.refute.plausible?("+855172345678")    # Mobitel (too long)
     Phony.assert.plausible?("+85592122417")     # Mobitel (6 digit extended range id)
     Phony.assert.plausible?("+855121234567")    # Mobitel (7 digit extended range id)
@@ -255,8 +256,8 @@ http://www.khmerdigitalpost.com/mobile-operators-in-cambodia-by-2015/
     Phony.refute.plausible?("+855188700545")    # Excell (too long)
     Phony.refute.plausible?("+85518970054")     # Seatel (too short)
 
-    Phony.assert.plausible?("+855399999898")    # EMAXX  (7 digit id)
-    Phony.refute.plausible?("+85539999989")     # EMAXX  (too short)
+    Phony.assert.plausible?("+855399999898")    # Kingtel  (7 digit id)
+    Phony.refute.plausible?("+85539999989")     # Kingtel  (too short)
 
     Phony.refute.plausible?("+85512023456")     # invalid numbering plan
     Phony.refute.plausible?("+85510123456")     # invalid numbering plan


### PR DESCRIPTION
This fixes a bug which was introduced by accident in https://github.com/floere/phony/commit/94843365b337c43d1dfba28d5877007e54718951