### PR TITLE
Update rules for NZ numbers

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -274,6 +274,8 @@ Phony.define do
     match(/^(2\d)\d{7}$/) >> split(3,4)   | # Mobile
     match(/^(2\d)\d{6}$/) >> split(3,3)   |
     match(/^(2\d)\d{8}$/) >> split(2,3,3) |
+    match(/^(800)\d{6}$/) >> split(3,3)   | # International 800 service where agreed
+    match(/^(800)\d{7}$/) >> split(3,4)   | # International 800 service where agreed
     fixed(1) >> split(3,4)                  # Rest
 
   # Singapore (Republic of).

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -218,6 +218,10 @@ describe 'plausibility' do
                                               '+977 10 123 456',
                                               '+977 98 1234 5678']
       it_is_correct_for "New Caledonia (Territoire français d'outre-mer)", :samples => '+687  546 835'
+      it 'is correct for New Zealand' do
+        Phony.plausible?('+64800123123').should be_true # Free phone
+        Phony.plausible?('+648001231234').should be_true # Free phone
+      end
       it_is_correct_for 'Nicaragua', :samples => '+505 12 345 678'
       it_is_correct_for 'Niger', :samples => '+227  1234 5678'
       it_is_correct_for 'Niue', :samples => '+683  3791'

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -794,6 +794,8 @@ describe 'country descriptions' do
     end
     describe 'New Zealand' do
       it_splits '6491234567', ['64', '9', '123', '4567']
+      it_splits '64800123123', ['64', '800', '123', '123']
+      it_splits '648001231234', ['64', '800', '123', '1234']
     end
     describe 'Bhutan (Kingdom of)' do
       it_splits '9759723642', %w(975 9 723 642)


### PR DESCRIPTION
Update rules for NZ numbers to allow 800 followed by 6 or 7 digits.

Source: https://www.itu.int/dms_pub/itu-t/oth/02/02/T02020000990001PDFE.pdf (3 page)