### PR TITLE
Fixes NDCs that overlaps with service numbers in Sweden

### DIFF
--- a/lib/phony/countries/sweden.rb
+++ b/lib/phony/countries/sweden.rb
@@ -43,29 +43,35 @@ mobile = [
  '76', # Mobile
  '79', # Mobile
 ]
-service = [
-    '99', # Premium Rate
-   '112', # Emergency Service
-   '116', # Psychological Help
-   '118', # Number enquiries
-   '900', # Premium Rate
-   '939', # Premium Rate
-   '944', # Premium Rate
-  '1177', # Health Care Advice
- '11414', # Police
+services = [
+    '112', # Emergency Service
+   '1177', # Health Care Advice
+  '11414', # Police
+]
+service_ndcs = [
+  '99',  # Premium Rate
+  '900', # Premium Rate
+  '939', # Premium Rate
+  '944', # Premium Rate
+]
+three_digit_service = [
+  '116', # Psychological Help (116 xxx)
+  '118', # Number enquiries (118 xxx)
 ]
 
 Phony.define do
   country '46',
     trunk('0') |
-    one_of(service)       >> split(3,3)   |
-    one_of(ndcs + mobile) >> matched_split(
+    match(/^(#{services.join('|')})$/) >> split(0) |
+    one_of(service_ndcs)       >> split(3,3) |
+    match(/^(#{three_digit_service.join('|')})\d{3}$/) >> split(3) |
+    one_of(ndcs + mobile)      >> matched_split(
       /^\d{5}$/ => [3, 2],
       /^\d{6}$/ => [2, 2, 2],
       /^\d{7}$/ => [3, 2, 2],
       /^\d{8}$/ => [3, 2, 3]
     ) |
-    fixed(3)              >> matched_split(
+    fixed(3)                   >> matched_split(
       /^\d{5}$/ => [3, 2],
       /^\d{6}$/ => [2, 2, 2]
     )

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -854,6 +854,11 @@ With regexp constraints.
     Phony.assert.plausible?('+46 513 12 34 56')
     Phony.refute.plausible?('+46 513 12 34 567') # too long
     Phony.refute.plausible?('+46 19 20 88') # too short
+    Phony.refute.plausible?('+46 11 22 33') # too short and starts with a service number
+    Phony.assert.plausible?('+46 118 800')
+    Phony.assert.plausible?('+46 11 222 333')
+    Phony.assert.plausible?('+46 11 622 333')
+    Phony.assert.plausible?('+46 11 822 333')
 
 #### Vietnam
 


### PR DESCRIPTION
E.g. local numbers in Norrköping that begins with 2, 6 or 8