### PR TITLE
Validate South Korea land numbers

### DIFF
--- a/lib/phony/countries/south_korea.rb
+++ b/lib/phony/countries/south_korea.rb
@@ -1,22 +1,24 @@
 # South Korean (Republic of Korea) phone numbers.
 #
 # http://en.wikipedia.org/wiki/Telephone_numbers_in_South_Korea
+# https://www.numberingplans.com/?page=plans&sub=phonenr&alpha_2_input=KR
 #
 
 # TODO 4-digit services, like "unreasonable infringement of livelihood report" number :)
 #
 
 special = %w{ 100 101 105 106 107 108 109 111 112 113 114 115 116 117 118 119 120 121 122 123 125 127 128 129 131 132 134 141 182 188 }
-# mobile  = ('10'..'19').to_a # Note: Mobile not used as it is (for now) handled by the fixed catchall.
+mobile  = ('10'..'19').to_a
 
 Phony.define do
   country '82',
     trunk('0') |
     match(/^(#{special.join("|")})$/) >> split(3,3) | # Special actually don't need to be split – but better err.
-    one_of('2')                       >> split(4,4) | # Seoul, also includes "services".
-    fixed(2)                          >> split(4,4)   # Catchall.
-    
-    # See above.
-    #
-    # one_of(*mobile)                 >> split(4,4) |
+    one_of(*mobile) >> split(4,4) |
+    one_of('2') >> matched_split(
+      /\A\d{7}\z/ => [3,4],
+      /\A\d{8}\z/ => [4,4]) | # Seoul, also includes "services".
+    fixed(2) >> matched_split(
+      /\A\d{7}\z/ => [3,4],
+      /\A\d{8}\z/ => [4,4]) # Rest of cities
 end

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -280,6 +280,16 @@ describe 'plausibility' do
                                                                    '+252 160 12 34',
                                                                    '+252 500 123 45',
                                                                    '+252 67 1234 567']
+
+      it 'is correct for South Korea' do
+        Phony.plausible?('+82 2 1234 5678').should be_truthy
+        Phony.plausible?('+82 2 711 2222').should be_truthy
+        Phony.plausible?('+82 51 1234 5678').should be_truthy
+        Phony.plausible?('+82 51 123 5678').should be_truthy
+        Phony.plausible?('+82 10 2797 5588').should be_truthy
+        Phony.plausible?('+82 10 8797 1234').should be_truthy
+      end
+
       it_is_correct_for 'South Sudan', :samples => ['+211 123 212 345',
                                                     '+211 973 212 345']
       it_is_correct_for 'Suriname (Republic of)', :samples => ['+597 212 345', '+597 612 3456']

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -632,8 +632,10 @@ describe 'country descriptions' do
       it_splits '2399920012', %w(239 9 920 012)
     end
     describe 'South Korea' do
-      it_splits '82212345678',  ['82', '2', '1234', '5678']  # Seoul
-      it_splits '825112345678', ['82', '51', '1234', '5678'] # Busan
+      it_splits '82212345678',  ['82', '2', '1234', '5678']  # Seoul (8 digits)
+      it_splits '8227111222',   ['82', '2', '711', '1222']   # Seoul (7 digits)
+      it_splits '825112345678', ['82', '51', '1234', '5678'] # Busan (8 digits)
+      it_splits '82511234567',  ['82', '51', '123', '4567']  # Busan (7 digits)
       it_splits '821027975588', ['82', '10', '2797', '5588'] # mobile
       it_splits '821087971234', ['82', '10', '8797', '1234'] # mobile
     end


### PR DESCRIPTION
In South Korean land numbers could have 7 or 8 digits.

Here you can see valid patterns for land numbers:

* https://www.numberingplans.com/?page=plans&sub=phonenr&alpha_2_input=KR&current_page=10