### PR TITLE
Sat phone support

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -1024,7 +1024,12 @@ Phony.define do
   # Bangladesh (People's Republic of)
   #  country '880' # see special file
 
-  country '881', todo # International Mobile, shared code
+  # Global Mobile Satellite System (i.e. Iridium, Globalstar, etc)
+  #  https://www.numberingplans.com/?page=plans&sub=phonenr&alpha_2_input=QM
+  country '881',
+          none >> matched_split(/^[23].*$/  => [8], # Ellipso (see url above)
+                                :fallback   => [10])
+
   country '882', todo # International Networks, shared code
   country '883', todo # -
   country '884', todo # -

--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -1026,9 +1026,7 @@ Phony.define do
 
   # Global Mobile Satellite System (i.e. Iridium, Globalstar, etc)
   #  https://www.numberingplans.com/?page=plans&sub=phonenr&alpha_2_input=QM
-  country '881',
-          none >> matched_split(/^[23].*$/  => [7], # Ellipso (see url above)
-                                :fallback   => [10])
+  country '881', fixed(1) >> split(3,5)
 
   country '882', todo # International Networks, shared code
   country '883', todo # -

--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -1027,7 +1027,7 @@ Phony.define do
   # Global Mobile Satellite System (i.e. Iridium, Globalstar, etc)
   #  https://www.numberingplans.com/?page=plans&sub=phonenr&alpha_2_input=QM
   country '881',
-          none >> matched_split(/^[23].*$/  => [8], # Ellipso (see url above)
+          none >> matched_split(/^[23].*$/  => [7], # Ellipso (see url above)
                                 :fallback   => [10])
 
   country '882', todo # International Networks, shared code

--- a/qed/format.md
+++ b/qed/format.md
@@ -208,23 +208,28 @@ With forced trunk.
     Phony.format('263783123456', :format => :international).assert == '+263 78 312 3456'
     Phony.format('263783123456', :format => :national).assert == '078 312 3456'
 
+#### Global Mobile Satellite System
+
+    Phony.format('881632647870', :format => :international).assert == '+881 6 326 47870'
+    Phony.format('881632647870', :format => :national).assert == '6 326 47870'
+
 #### Unsupported Countries
 
 Formats as a single block.
 
-    Phony.format('88132155605220').assert == '+881 32155605220'
+    Phony.format('88232155605220').assert == '+882 32155605220'
 
 Formats as a single block, regardless of format.
 
-    Phony.format('8811819372205', :format => :international).assert == '+881 1819372205'
+    Phony.format('8821819372205', :format => :international).assert == '+882 1819372205'
 
 Formats as a single block, respecting custom spaces.
 
-    Phony.format('8811819372205', :spaces => :-).assert == '+881-1819372205'
+    Phony.format('8821819372205', :spaces => :-).assert == '+882-1819372205'
 
 Formats as a single block, even without spaces.
 
-    Phony.format('8811819372205', :spaces => '').assert == '+8811819372205'
+    Phony.format('8821819372205', :spaces => '').assert == '+8821819372205'
 
 ### Special cases
 


### PR DESCRIPTION
This PR adds support for satellite phone numbers. Note that the old 'Unsupported Countries' test needed to be changed as it was using the sat phone CC to verify handling of what was then an unsupported CC.