### PR TITLE
Add support from Kosovo phone numbers

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -733,7 +733,13 @@ Phony.define do
 
   # country '382' # Montenegro, see special file
 
-  country '383', todo # -
+  # Kosovo
+  #
+  # Note: https://en.wikipedia.org/wiki/Telephone_numbers_in_Kosovo
+  country '383',
+          trunk('0') |
+          fixed(2) >> split(3,3)
+
   country '384', todo # -
 
   # country '385' # Croatia, see special file.

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -411,6 +411,11 @@ describe 'plausibility' do
       it 'is correct for Russia' do
         Phony.plausible?('+7 3522 000 000').should be_truthy
       end
+
+      it 'is correct for Kosovo' do
+        Phony.plausible?('+383 29 000 000').should be_truthy # Landline
+        Phony.plausible?('+383 44 000 000').should be_truthy # Mobile
+      end
     end
   end
 end

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -442,6 +442,10 @@ describe 'country descriptions' do
       it_splits '254111234567', ['254', '11', '1234567'] # Mombasa
       it_splits '254723100220', ['254', '723', '100220'] # Mombasa
     end
+    describe 'Kosovo' do
+      it_splits '38329000000', ['383', '29', '000', '000'] # Landline
+      it_splits '38344000000', ['383', '44', '000', '000'] # Mobile
+    end
     describe 'Kyrgyzstan' do
       it_splits '996312212345', %w(996 312 212 345)
       it_splits '996315212345', %w(996 315 212 345)


### PR DESCRIPTION
Add support for Kosovo phone numbers (prefix +383)

Reference: https://en.wikipedia.org/wiki/Telephone_numbers_in_Kosovo