### PR TITLE
Fix Peru landline number validation

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -184,11 +184,13 @@ Phony.define do
   # country '49' # Germany, see special file.
 
   # Peru.
-  #
+  # Note: https://en.wikipedia.org/wiki/Telephone_numbers_in_Peru
+  # Note: https://www.numberingplans.com/?page=plans&sub=phonenr&alpha_2_input=PE
   country '51',
           one_of('103', '105') >> split(3,3) | # Service.
-          one_of('1', '9')     >> split(4,4) | # Lima and mobile.
-          fixed(2)             >> split(4,4)   # 2-digit NDCs.
+          one_of('9')          >> split(4,4) | # Mobile.
+          one_of('1')          >> split(3,4) | # Lima.
+          fixed(2)             >> split(3,3)   # 2-digit NDCs.
 
   # Mexico.
   #

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -411,6 +411,12 @@ describe 'plausibility' do
       it 'is correct for Russia' do
         Phony.plausible?('+7 3522 000 000').should be_truthy
       end
+
+      it 'is correct for Peru' do
+        Phony.plausible?('+51 1 123 1234').should be_truthy # Lima
+        Phony.plausible?('+51 9 1234 1234').should be_truthy # mobile
+        Phony.plausible?('+51 84 123 123').should be_truthy # Cuzco, best effort
+      end
     end
   end
 end

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -563,9 +563,9 @@ describe 'country descriptions' do
       it_splits '595961611234', %w(595 96 161 1234)
     end
     describe 'Peru' do
-      it_splits '51112341234', ['51', '1', '1234', '1234'] # Lima
+      it_splits '5111231234', ['51', '1', '123', '1234'] # Lima
       it_splits '51912341234', ['51', '9', '1234', '1234'] # mobile
-      it_splits '51841234123', ['51', '84', '1234', '123'] # Cuzco, best effort
+      it_splits '5184123123', ['51', '84', '123', '123'] # Cuzco, best effort
     end
     describe 'Philippines' do
       it_splits '6321234567', ['63', '2', '1234567']


### PR DESCRIPTION
Peru landline numbers consist of 8 digits after the country prefix:
* 1 + 7 additional digits for Lima
* 2 digit area code and 6 additional digits for the rest of the areas

According to the following two references:
* https://en.wikipedia.org/wiki/Telephone_numbers_in_Peru
* https://www.numberingplans.com/?page=plans&sub=phonenr&alpha_2_input=PE

Lima landlines do not follow the same formats as mobile numbers. Lima landlines start with a `1` followed by 7 digits, while mobile numbers start with a `9` followed by 8 more digits. Hence they should be handled by different rules.

**Note**: This may introduce backwards incompatible changes as it no longer validates numbers like: `+51 1 0000 0000` which were considered plausible before.