### PR TITLE
Patch country splitter to accept  ndc with seven digit landline subscriber

### DIFF
--- a/lib/phony/countries/malaysia.rb
+++ b/lib/phony/countries/malaysia.rb
@@ -4,7 +4,6 @@
 #
 ndcs = [
   '2', # Singapore
-  '3', # Selangor & Federal Territories of Kuala Lumpur & Putrajaya & also Genting Highlands, Pahang
   '4', # Kedah, Penang & Perlis
   '5', # Perak & Cameron Highlands (Pahang)
   '6', # Melaka, Negeri Sembilan & Muar (Johor)
@@ -14,6 +13,9 @@ ndcs = [
 mobile = %w{ 10 11 12 13 14 153 154 156 158 16 17 18 19 }
 # service = %w{ 100 101 102 103 104 108 991 994 995 999 }  # Emergeny and Service numbers, only 3 digits long
 freephone = %w{ 300 700 800 }
+ndcs_eight = [
+  '3' # Selangor & Federal Territories of Kuala Lumpur & Putrajaya & also Genting Highlands, Pahang
+]
 
 Phony.define do
   country '60',
@@ -21,6 +23,7 @@ Phony.define do
     one_of(freephone) >> split(2,4) | # Freephone, Tollfree, Forwarding
     # one_of(service) >>  none  | # Service
     one_of(mobile)  >> split(3,4..5)   | # Mobile
-    one_of(ndcs)    >> split(8)     | # 1-digit NDCs
+    one_of(ndcs)    >> split(7)     | # 1-digit NDCs
+    one_of(ndcs_eight)    >> split(8)     | # 1-digit NDCs
     fixed(2)        >> split(8)       # 2-digit NDCs (Also, fallback)
 end

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -430,6 +430,10 @@ describe 'plausibility' do
         Phony.plausible?('+359 30 123 123').should be_truthy    # Landline
         Phony.plausible?('+359 89 123 1234').should be_truthy   # Mobile
       end
+
+      it 'is correct for Malaysia' do
+        Phony.plausible?('+60 5 123 1234').should be_truthy     # Non Selangor Landline
+      end
     end
   end
 end


### PR DESCRIPTION
Prior to this PR, 7-digit landline subscriber numbers are regarded as non-plausible number by `Phony.plausible?` regardless of the area code. 

Example:
```
Phony.plausible?('+6053210306')
=> false # Getting false result but this is a valid landline number in Malaysia
```

As stated in [wiki_malaysia_number](https://en.wikipedia.org/wiki/Telephone_numbers_in_Malaysia), 
> Thus, a full national number is 10 digits in area code 3 and 9 digits elsewhere, including the STD prefix 0. When writing a telephone number with the area code, the area code and subscriber number is separated with a hyphen. 

In other word, landline subscriber number in area code **3** will have 8-digits and 7-digits elsewhere (excluding ndc).

The objective of this PR is to fix the above issue by making 7-digits landline number that's not from area code **3** being plausible.