### PR TITLE
Add Additional UAE Tollfree Format

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -1155,7 +1155,8 @@ Phony.define do
           one_of(%w(500 700 900)) >> split(3,3) | # premium rate
           one_of('800') >> matched_split(
               /\A\d{2}\z/ => [2],
-              /\A\d+\z/ => [2,3,4]) | # freephone
+              /\A\d+\z/ => [2,3,2],
+              /\A\d+\z/ => [2,3,4])| # freephone
           one_of(%w(50 52 54 55 56 58)) >> split(3,4) | # mobile
           one_of(%w(2 3 4 6 7 9)) >> split(3,4) |
           fixed(1) >> split(3,4)

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -1308,6 +1308,7 @@ describe 'country descriptions' do
     describe 'United Arab Emirates' do
       it_splits '97180012', %w(971 800 12)
       it_splits '971800123456789', %w(971 800 12 345 6789)
+      it_splits '9718001234567', %w(971 800 12 345 67)
       it_splits '97121234567', %w(971 2 123 4567)
       it_splits '971506412345', %w(971 50 641 2345)
       it_splits '971600641234', %w(971 600 641 234)


### PR DESCRIPTION
When provisioning UAE tollfree numbers from Twilio the only available are of the format 2/3/2, which is rejected as an incorrect format currently. This update adds support for the 2/3/2 format.