### PR TITLE
Vn đà nẵng city

### DIFF
--- a/lib/phony/countries/vietnam.rb
+++ b/lib/phony/countries/vietnam.rb
@@ -16,6 +16,7 @@ ndcs_with_7_subscriber_digits = [
   '22',  # Sơn La Province
   '230', # Điện Biên Province (23 before 24 Nov 2007)
   '231', # Lai Châu Province (23 before 24 Nov 2007)
+  '236', # Đà-Nẵng City
   '240', # Bắc Giang Province
   '241', # Bắc Ninh Province
   '25',  # Lạng Sơn Province

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -330,6 +330,7 @@ describe 'plausibility' do
       it_is_correct_for 'Tuvalu', :samples => '+688  93742'
       it_is_correct_for 'Uzbekistan (Republic of)', :samples => '+998 78 867 4419'
       it_is_correct_for 'Vanuatu (Republic of)', :samples => ['+678  7216 123', '+678  26 123']
+      it_is_correct_for 'Vietnam', :samples => ['+84 236 1234567']
       it_is_correct_for 'Lybia', :samples => ['+218 205 123 45',
                                               '+218 22 123 456',
                                               '+218 21 1234 456',

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -792,6 +792,7 @@ describe 'country descriptions' do
       it_splits '8498123456', ['84', '98', '123456'] # Viettel Mobile
       it_splits '8499612345', ['84', '99', '612345'] # GTel
       it_splits '84412345678', ['84', '4', '1234', '5678'] # Hanoi
+      it_splits '842361234567', ['84', '236', '123', '4567'] # Đà Nẵng
     end
     describe 'Zambia' do
       it_splits '260211123456', ['260', '211', '123456']     # Fixed


### PR DESCRIPTION
Đà Nẵng has an additional area code of 236 per:
https://en.wikipedia.org/wiki/Telephone_numbers_in_Vietnam
This commit adds support for this new area code.