### PR TITLE
Expand the maximum length of phone numbers and allow long German numbers

### DIFF
--- a/lib/phony/country_codes.rb
+++ b/lib/phony/country_codes.rb
@@ -97,7 +97,7 @@ module Phony
 
       # False if it fails the basic check.
       #
-      return false unless (4..15) === normalized.size
+      return false unless (4..16) === normalized.size
 
       country, cc, rest = partial_split normalized
 


### PR DESCRIPTION
There is a German number that is quite long and `Phony.plausible?` returns false for that, however it's valid. The number is like `+49 6691 12345 67890` and it's 16 digits long. The number seems to be a valid landline number of Deutsche Telekom. If I increase the phone number length limit from 15 to 16 then it's also valid in Phony.