### PR TITLE
Add support for hong kong toll free numbers

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -1025,6 +1025,7 @@ Phony.define do
   # Hong Kong, China
 
   country '852',
+          match(/^(800)\d+$/) >> split(2, 4) |
           none >> split(4,4)
 
   # Macao, China

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -499,6 +499,12 @@ Mobile.
       '+30 909 123 4565'
     ]
 
+#### Hong Kong
+    plausible? true: [
+        '+852800121234',    # Toll Free
+        '+85212341234',     # Other Numbers
+    ]
+
 #### Hungary
 
     plausible? true: [

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -329,7 +329,8 @@ describe 'country descriptions' do
     end
 
     describe 'Hong Kong' do
-      it_splits '85212341234', ['852', false, '1234', '1234']     #
+      it_splits '85212341234', ['852', false, '1234', '1234']    #Other Numbers
+      it_splits '852800121234', ['852', '800', '12', '1234']     #Toll Free
     end
 
     describe 'Hungary' do


### PR DESCRIPTION
Per wikipedia page Hong Kong toll free number format is (852) 800 XX XXXX.

 This PR adds support for toll free while maintaining support for non DNC formatting. Includes specs and qed update.  

Source: https://en.wikipedia.org/wiki/Telephone_numbers_in_Hong_Kong 