### PR TITLE
Update Israeli phone prefixes

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -1185,7 +1185,7 @@ Phony.define do
     trunk('0') |
     one_of('1')                            >> split(3,3,3) | # special numbers
     one_of('2', '3', '4', '8', '9')        >> split(3,4)   | # 1 digit ndc
-    match(/^(5[023456789]|7[23467])\d+$/)  >> split(3,4)     # 2 digit ndc
+    match(/^(5[012345689]|7[23467])\d+$/)  >> split(3,4)     # 2 digit ndc
 
   country '973', none >> split(4,4..4) # Bahrain (Kingdom of) http://www.itu.int/oth/T0202000011/en
 

--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -1183,9 +1183,9 @@ Phony.define do
   # Israel (State of) (also works for numbers in Palestinian territories)
   country '972',
     trunk('0') |
-    one_of('1')                            >> split(3,3,3) | # special numbers
-    one_of('2', '3', '4', '8', '9')        >> split(3,4)   | # 1 digit ndc
-    match(/^(5[012345689]|7[23467])\d+$/)  >> split(3,4)     # 2 digit ndc
+    one_of('1')                                 >> split(3,3,3) | # special numbers
+    one_of('2', '3', '4', '8', '9')             >> split(3,4)   | # 1 digit ndc
+    match(/^(5[012345689]|7[234679])\d+$/)      >> split(3,4)     # 2 digit ndc
 
   country '973', none >> split(4,4..4) # Bahrain (Kingdom of) http://www.itu.int/oth/T0202000011/en
 

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -558,8 +558,12 @@ Mobile.
 
 #### Israel
 
-    Phony.assert.plausible?('+972 2 123 1234')
-    Phony.assert.plausible?('+972 59 123 1234')
+    plausible? true: [
+      '+972 2 123 1234',
+      '+972 59 123 1234',
+      '+972 51 123 1234',
+      '+972 79 123 1234',
+    ]
 
 #### Italy
 

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -410,15 +410,16 @@ describe 'country descriptions' do
     end
 
     describe 'Israel (972)' do
-      it_splits '972100',       ['972', '1', '00']  # Police
-      it_splits '97221231234',  ['972', '2', '123', '1234']  # Jerusalem Area
-      it_splits '97282411234',  ['972', '8', '241', '1234']  # Gaza Strip (Palestine)
-      it_splits '97291231234',  ['972', '9', '123', '1234']  # Sharon Area
-      it_splits '972501231234', ['972', '50', '123', '1234']  # Mobile (Pelephone)
-      it_splits '972591231234', ['972', '59', '123', '1234']  # Mobile Jawwal (Palestine)
-      it_splits '972771231234', ['972', '77', '123', '1234']  # Cable Phone Services
+      it_splits '972100',       ['972', '1', '00']                  # Police
+      it_splits '97221231234',  ['972', '2', '123', '1234']         # Jerusalem Area
+      it_splits '97282411234',  ['972', '8', '241', '1234']         # Gaza Strip (Palestine)
+      it_splits '97291231234',  ['972', '9', '123', '1234']         # Sharon Area
+      it_splits '972501231234', ['972', '50', '123', '1234']        # Mobile (Pelephone)
+      it_splits '972591231234', ['972', '59', '123', '1234']        # Mobile Jawwal (Palestine)
+      it_splits '972771231234', ['972', '77', '123', '1234']        # Cable Phone Services
       it_splits '9721700123123', ['972', '1', '700', '123', '123']  # Cable Phone Services
-      it_splits '972511234567', ['972', '51', '123', '4567'] # Mobile (We4G)
+      it_splits '972511234567', ['972', '51', '123', '4567']        # Mobile (We4G)
+      it_splits '972791111111', ['972', '79', '111', '1111']        # Landline (Hallo, Cellact, Telzar)
     end
     describe 'Israel (970)' do
       it_splits '97021231234',  ['970', '2', '123', '1234']  # Jerusalem Area

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -418,6 +418,7 @@ describe 'country descriptions' do
       it_splits '972591231234', ['972', '59', '123', '1234']  # Mobile Jawwal (Palestine)
       it_splits '972771231234', ['972', '77', '123', '1234']  # Cable Phone Services
       it_splits '9721700123123', ['972', '1', '700', '123', '123']  # Cable Phone Services
+      it_splits '972511234567', ['972', '51', '123', '4567'] # Mobile (We4G)
     end
     describe 'Israel (970)' do
       it_splits '97021231234',  ['970', '2', '123', '1234']  # Jerusalem Area


### PR DESCRIPTION
According to: https://en.wikipedia.org/wiki/Telephone_numbers_in_Israel\#Cellular_and_mobile_devices_area_code_05

Additions:
- 051
- 079

Removal:
- 057