### PR TITLE
Accept area code 8 for philippine mobile number

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -267,6 +267,7 @@ Phony.define do
     one_of('2') >> split(7) |
     # mobile
     match(/\A(9\d\d)\d{7}\z/) >> split(7) |
+    match(/\A(8\d\d)\d{7}\z/) >> split(7) |
     match(/\A(9\d\d)\d+\z/) >> split(6) |
     #
     fixed(2) >> split(7)

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -598,6 +598,11 @@ describe 'plausibility' do
         Phony.plausible?('+81 120 123 123').should be_truthy
         Phony.plausible?('+81 800 123 1234').should be_truthy
       end
+
+      it 'is correct for Philippine' do
+        Phony.plausible?('+63 976 1234567').should be_truthy # mobile phone with area code 9
+        Phony.plausible?('+63 876 1234567').should be_truthy # mobile phone with area code 8
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is to patch the Philippine mobile phone matcher to accept area code **8** as plausible number.

Reference:
[wiki](https://en.wikipedia.org/wiki/Telephone_numbers_in_the_Philippines)
> Mobile phone area codes are three digits long and always start with the number 9, although recently new area codes have been issued with 8 as the starting digit, particularly for VOIP phone numbers. However, the area code indicates the service provider and not necessarily a geographic region....