### PR TITLE
fix plausibility for Argentina international mobile numbers

### DIFF
--- a/lib/phony/countries/argentina.rb
+++ b/lib/phony/countries/argentina.rb
@@ -348,8 +348,8 @@ Phony.define do
       one_of(area_codes_4digits) >> split(2, 4) | # landline
       one_of(area_codes_3digits) >> split(3, 4) | # landline
       one_of(area_codes_2digits) >> split(4, 4) | # landline
-      one_of(area_codes_2digits.map{|x| "9#{x}" }) >> split(4, 5) | # mobile
-      one_of(area_codes_3digits.map{|x| "9#{x}" }) >> split(3, 5) | # mobile
-      one_of(area_codes_4digits.map{|x| "9#{x}" }) >> split(2, 5) | # mobile
+      one_of(area_codes_2digits.map{|x| "9#{x}" }) >> split(4, 4) | # mobile
+      one_of(area_codes_3digits.map{|x| "9#{x}" }) >> split(3, 4) | # mobile
+      one_of(area_codes_4digits.map{|x| "9#{x}" }) >> split(2, 4) | # mobile
       one_of(special_numbers)            >> split(3, 4)
 end

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -56,6 +56,18 @@ Some of the examples use `plausible? true: [some numbers]`.
     Phony.refute.plausible?('+355 85 12345') # too short
     Phony.refute.plausible?('+355 85 1234567') # too long
 
+#### Argentina
+
+    Phony.assert.plausible?('+54 11 1234 5678') # 2-digit area code / landline
+    Phony.assert.plausible?('+54 291 123 4567') # 3-digit area code / landline
+    Phony.assert.plausible?('+54 2903 12 3456') # 4-digit area code / landline
+    Phony.assert.plausible?('+54 911 1234 5678') # 2-digit area code / international mobile
+    Phony.assert.plausible?('+54 9220 123 4567') # 3-digit area code / international mobile
+    Phony.assert.plausible?('+54 92221 12 3456') # 4-digit area code / international mobile
+    Phony.assert.plausible?('+54 800 123 4567') # Non-geographic number
+    Phony.refute.plausible?('+54 800 123 456')   # too short
+    Phony.refute.plausible?('+54 800 123 45678') # too long
+
 #### Armenia
 
     Phony.assert.plausible?('+374 12345678')


### PR DESCRIPTION
Proposed fix for https://github.com/floere/phony/issues/444

With release of `2.18.5` `Phony.plausible?` is returning `false` for Argentina internal mobile numbers, [including the ones that are used in the `split` tests](https://github.com/floere/phony/blob/81d392f020140abe3fd650dd056821432efd542c/spec/lib/phony/countries_spec.rb#L36-L42). Added plausibility tests for those numbers.