### PR TITLE
Updating Austrian number requirements

### DIFF
--- a/lib/phony/countries/austria.rb
+++ b/lib/phony/countries/austria.rb
@@ -85,7 +85,7 @@ service = [
  '939'
 ]
 
-# https://www.rtr.at/en/tk/E129/2312_Austrian_Numbering_Plan_2011-03-30.pdf
+# https://www.rtr.at/en/tk/E129/Austrian_Numbering_Plan_2011-03-30.pdf
 #
 # TODO Add more details.
 #
@@ -97,7 +97,7 @@ Phony.define do
                 one_of('800')            >> split(6..10)  | # Free number length is 9..13
                 one_of(corporate_2digit) >> split(3..11)  | # Corporate number length is 5..13
                 one_of(corporate)        >> split(2..10)  | # Corporate number length is 5..13
-                one_of(ndcs)             >> split(6..10)  |
+                one_of(ndcs)             >> split(5..10)  |
                 one_of('663')            >> split(6..8)   | # 6..8 digit mobile.
                 one_of(mobile)           >> split(4,3..9) |
                 one_of(mobile_2digit)    >> split(7..7)   | # Separate as mobile contains 676 - 67 violates the prefix rule.

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -46,7 +46,8 @@ describe 'plausibility' do
     end
 
     context 'specific countries' do
-      it_is_correct_for 'Austria', :samples => '+43 720 116987' # VoIP
+      it_is_correct_for 'Austria', :samples => ['+43 720 116987', # VoIP
+                                                '+43 463 12345'] # Klagenfurt
       it_is_correct_for 'Bosnia and Herzegovina', :samples => ['+387 66 666 666',
                                                                '+387 37 123 456',
                                                                '+387 33 222 111']


### PR DESCRIPTION
* Updated the link to the Austrian numbering plan (nothing changed, just the URL)
* Updated the length requirements for `ndcs` numbers from 6 to 5

I have an example of a valid number for the Klagenfurt region that has 5 digits after the ndc code.
I'm not sure if the change included here is good or should I split `463` into it's own case?