### PR TITLE
Improve Area codes recognition for Nigeria

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -386,14 +386,19 @@ Phony.define do
   country '233', fixed(2) >> split(3,4)
 
   # Nigeria
-  # Wikipedia says 3 4 split, many local number with no splitting
+  # 3 4 split for mobile and 1 digit NDC, 3 2 or 3 3 otherwise
+  # Many local numbers with no splitting
   #
-  # mobile telephony number allocation taken from: http://www.ncc.gov.ng/index.php?option=com_content&view=article&id=113&Itemid=102
+  # mobile telephony number allocation taken from:
+  # https://www.ncc.gov.ng/technical-regulation/standards/numbering and
+  # https://www.itu.int/oth/T020200009C/en
   country '234',
-    match(/^([7-9]0\d)\d+$/) >> split(3,4) | # Mobile
-    match(/^(81\d)\d+$/)     >> split(3,4) | # Mobile
-    one_of('1', '2', '9')    >> split(3,4) | # Lagos, Ibadan and Abuja
-    fixed(2)                 >> split(3,4)   # 2-digit NDC
+    match(/^([7-9]0\d)\d+$/)            >> split(3,4)    | # Mobile
+    match(/^(81\d)\d+$/)                >> split(3,4)    | # Mobile
+    one_of('1', '2')                    >> split(3,3..4) | # Lagos, Ibadan
+    one_of('9')                         >> split(3,4)    | # Abuja
+    one_of((30..79).map(&:to_s))        >> split(3,2..3) | # 2-digit NDC
+    one_of(%w(82 83 84 85 86 87 88 89)) >> split(3,3)      # 2-digit NDC
 
   country '235', none >> split(4,4) # Chad http://www.wtng.info/wtng-235-td.html
   country '236', none >> split(4,4) # Central African Republic http://www.wtng.info/wtng-236-cf.html

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -355,6 +355,11 @@ describe 'plausibility' do
       end
       it_is_correct_for 'Nicaragua', :samples => '+505 12 345 678'
       it_is_correct_for 'Niger', :samples => '+227  1234 5678'
+      it_is_correct_for 'Nigeria', :samples => ['+234 807 059 1111',
+                                              '+234 811 234 5678',
+                                              '+234 64 830 00',
+                                              '+234 1 280 444',
+                                              '+234 85 123 456']
       it_is_correct_for 'Niue', :samples => '+683  3791'
       it_is_correct_for 'Oman', :samples => ['+968 24 423 123',
                                              '+968 25 423 123']

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -1103,6 +1103,8 @@ describe 'country descriptions' do
     describe 'Nigeria' do
       it_splits '23411231234', %w(234 1 123 1234) # Lagos
 
+      it_splits '23445123456', %w(234 45 123 456) # Ogoja
+
       # mobile numbers
       it_splits '2347007661234', %w(234 700 766 1234)
       it_splits '2347017661234', %w(234 701 766 1234)

--- a/spec/lib/phony/country_codes_spec.rb
+++ b/spec/lib/phony/country_codes_spec.rb
@@ -147,8 +147,11 @@ describe Phony::CountryCodes do
       it "should format luxembourgian numbers" do
         @countries.formatted('35227855', :format => :international).should eql '+352 27 85 5'
       end
-      it "should format nigerian numbers" do
+      it "should format nigerian lagosian numbers" do
         @countries.formatted('23414480000', :format => :international).should eql '+234 1 448 0000'
+      end
+      it "should format nigerian beninese numbers" do
+        @countries.formatted('23452123456', :format => :international).should eql '+234 52 123 456'
       end
       it "should format nigerian mobile numbers" do
         @countries.formatted('2347061234567', :format => :international).should eql '+234 706 123 4567'


### PR DESCRIPTION
Fixes https://github.com/floere/phony/issues/450

The area codes parsing code is changed from a 3, 4 split to a 3, 3 one, with more strict rules on the codes.
Doc links are also updated as the previous one was broken.