### PR TITLE
warning: Capturing the given block using Proc.new is deprecated; use `&block` instead

### DIFF
--- a/lib/phony/dsl.rb
+++ b/lib/phony/dsl.rb
@@ -12,9 +12,9 @@ module Phony
   #
   # Phony.define.country ...
   #
-  def self.define
+  def self.define(&block)
     dsl = DSL.new
-    dsl.instance_eval(&Proc.new) if block_given?
+    dsl.instance_eval(&block) if block_given?
     dsl
   end
 


### PR DESCRIPTION
I have just installed ruby-2.7.0-preview3 and found a lot of lines with these messages
Capturing the given block using Proc.new is deprecated; use `&block` instead
![image](https://user-images.githubusercontent.com/2146069/70604838-66502300-1c0a-11ea-884e-ede2220dd33e.png)

Ruby 2.7 is going to deprecate the magical behavior of calling Proc.new without passing a block.
ruby/ruby@9f1fb0a


