### PR TITLE
The domestic Telephone number in Japan has to have Trunk prefix.

### DIFF
--- a/qed/country-specific.md
+++ b/qed/country-specific.md
@@ -31,15 +31,38 @@ Yep. This turns out to be wrong. Only expects and handles normalized national nu
 
 #### Japan
 
+The domestic Telephone number in Japan has to have Trunk prefix.
+
+in Tokyo
+
 ```ruby
   japan = Phony["81"]
   
-  japan.format('8012345634', :format => :international).assert == '+81-80-1234-5634'
-  japan.format('8012345634', :format => :national).assert ==      '080-1234-5634'
-  japan.format('8012345634', :format => :local).assert ==         '1234-5634'
+  japan.format('0312345634', :format => :international).assert == '+81-3-1234-5634'
+  japan.format('0312345634', :format => :national).assert ==      '03-1234-5634'
+  japan.format('0312345634', :format => :local).assert ==         '1234-5634'
   
-  japan.normalize("80 1234 5634").assert == '8012345634'
-  japan.normalize("Hello    80 1234 5634").assert == '8012345634'
+  japan.normalize("03 1234 5634").assert == '0312345634'
+  japan.normalize("03-1234-5634").assert == '0312345634'
+  japan.normalize("03(1234)5634").assert == '0312345634'
+  japan.normalize("Hello    03-1234-5634").assert == '0312345634'
+  
+  japan.assert.plausible?('0312345678')
+```
+
+in Shihoro Town, Hokkaido
+
+```ruby
+  japan.format('0156452211', :format => :international).assert == '+81-1564-5-2211'
+  japan.format('0156452211', :format => :national).assert ==      '01564-5-2211'
+  japan.format('0156452211', :format => :local).assert ==         '5-2211'
+  
+  japan.normalize("01564 5 2211").assert == '0156452211'
+  japan.normalize("01564-5-2211").assert == '0156452211'
+  japan.normalize("01564(5)2211").assert == '0156452211'
+  japan.normalize("Hello   01564-5-2211 ").assert == '0156452211'
+  
+  japan.assert.plausible?('0156452211')
 ```
 
 #### Italy


### PR DESCRIPTION
The phone number for domestic calls seems a bit special in Japan.
Example telephone number in Japan, it is typlicaly 012-345-6789, (012)-345-6789, 012(345)6789, etc...
When calling within Japan, You will dial 0123456789. (https://www.world.jal.co.jp/world/en/guidetojapan/travelinfo/telephonedialing/)

At this time, each value is as follows:
Trunk prefix: 0
NDC: 12 (https://www.itu.int/oth/T020200006D/en)
Subscriber Number: 345-6789

However in Japan, the area code is supposed to be 012 (https://en.wikipedia.org/wiki/List_of_dialing_codes_in_Japan).
So, I want to return a normalized value with trunk prefix.

I think the behavior of this library is as follows:


```ruby
  japan = Phony["81"]
  
  japan.format('0312345634', :format => :international).assert == '+81-3-1234-5634'
  japan.format('0312345634', :format => :national).assert ==      '03-1234-5634'
  japan.format('0312345634', :format => :local).assert ==         '1234-5634'
  
  japan.normalize("03 1234 5634").assert == '0312345634'
  japan.normalize("03-1234-5634").assert == '0312345634'
  japan.normalize("03(1234)5634").assert == '0312345634'
  japan.normalize("Hello    03-1234-5634").assert == '0312345634'
  
  japan.assert.plausible?('0312345678')
```

Can the normalize method return a value with trunk prefix?
