### PR TITLE
Add testcase for Phony.normalize with/without :cc option for Japan.

### DIFF
--- a/qed/country-specific.md
+++ b/qed/country-specific.md
@@ -45,6 +45,7 @@ in Tokyo
   japan.normalize("03 1234 5634").assert == '0312345634'
   japan.normalize("03-1234-5634").assert == '0312345634'
   japan.normalize("03(1234)5634").assert == '0312345634'
+  japan.normalize("+81 3-1234-5634").assert == '0312345634'
   japan.normalize("Hello    03-1234-5634").assert == '0312345634'
   
   japan.assert.plausible?('0312345678')
@@ -60,6 +61,7 @@ in Shihoro Town, Hokkaido
   japan.normalize("01564 5 2211").assert == '0156452211'
   japan.normalize("01564-5-2211").assert == '0156452211'
   japan.normalize("01564(5)2211").assert == '0156452211'
+  japan.normalize("+81 1564-5-2211").assert == '0156452211'
   japan.normalize("Hello   01564-5-2211 ").assert == '0156452211'
   
   japan.assert.plausible?('0156452211')

--- a/qed/normalize.md
+++ b/qed/normalize.md
@@ -71,6 +71,11 @@ Handles a number with extra 0.
 
     Phony.normalize('36 0630245506').assert == '360630245506'
 
+#### Japan
+
+    Phony.normalize('+81 3-1234-5634').assert == '81312345634'
+    Phony.normalize('03-1234-5634', cc: '81').assert == '81312345634'
+
 #### Lithuania
 
     Phony.normalize('370 8 5 1234567').assert == '370851234567'


### PR DESCRIPTION
Thanks for last PR #453 merged.

Unfortunately, Phony.normalize with :cc option is broken.

The following is telephone number in Japan (all is same number):

+81 3-1234-5634 (international)
03-1234-5634 (from all area in Japan)
1234-5634 (from same area, in ths case From Tokyo to Tokyo)

So, I want to "normalize method" behaves as follows:

```ruby
Phony["81"].normalize('+81 3-1234-5634').assert == '0312345634'
Phony["81"].normalize('03-1234-5634').assert == '0312345634'
Phony.normalize('+81 3-1234-5634').assert == '81312345634'
Phony.normalize('03-1234-5634', cc: '81').assert == '81312345634'
```

But now:

```ruby
Phony["81"].normalize('+81 3-1234-5634')   => "81312345634"  # wrong, expected to national format "0312345634"
Phony["81"].normalize('03-1234-5634')        => "0312345634"    # right
Phony.normalize('+81 3-1234-5634')            => "81312345634"   # right
Phony.normalize('03-1234-5634', cc: '81')    => "810312345634" # wrong, expected to international format "81312345634"
```

Could you please fix this problem?
