### PR TITLE
Revert wrong change by #453.

### DIFF
--- a/lib/phony/countries/japan.rb
+++ b/lib/phony/countries/japan.rb
@@ -403,7 +403,7 @@ ndcs_with_5_subscriber_numbers = %w(
 
 Phony.define do
   country '81',
-    trunk('0', :normalize => false, :format => true, :split => true) |
+    trunk('0') |
     one_of('20', '50', '60', '70', '90')   >> split(4,4) | # mobile, VoIP telephony
     one_of(ndcs_with_5_subscriber_numbers) >> split(1,4) |
     one_of(ndcs_with_6_subscriber_numbers) >> split(2,4) |


### PR DESCRIPTION
Phony.normalize('03-1234-5634', cc: '81') expects '81312345634'
But now, '810312345634' (wrong)
So, Other libs based on Phony is broken too.
We must fix first.