### PR TITLE
Add trunk prefix for Ghana

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -382,8 +382,9 @@ Phony.define do
   # Ghana
   #
   # From http://www.itu.int/oth/T0202000052/en
+  # https://en.wikipedia.org/wiki/Telephone_numbers_in_Ghana
   #
-  country '233', fixed(2) >> split(3,4)
+  country '233', trunk('0') | fixed(2) >> split(3,4)
 
   # Nigeria
   # 3 4 split for mobile and 1 digit NDC, 3 2 or 3 3 otherwise

--- a/qed/format.md
+++ b/qed/format.md
@@ -18,7 +18,7 @@ It is aliased as `#formatted`, if that floats your boat.
     Phony.formatted('41443643532').assert == '+41 44 364 35 32'
 
 This is a very nice page for country specific formats:
-http://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers 
+http://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers
 
 ### Options
 
@@ -104,9 +104,12 @@ http://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers
     Phony.format('33142278186', :format => :+, :spaces => '').assert == '+33142278186'
     Phony.format('33142278186', :format => :+, :spaces => :-).assert == '+33-1-42-27-81-86'
 
+#### Ghana
+
+    Phony.format("233232437103", format: :national).assert == "023 243 7103"
 
 #### India
-      
+
     Phony.format('914433993939').assert == '+91 44 339 93 939'
 
 #### Italy
@@ -136,7 +139,7 @@ http://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers
     Phony.format('95930123456').assert == '+95 9 3012 3456'
     Phony.format('959250233059').assert == '+95 9 250 233 059'
     Phony.format('959427123456').assert == '+95 9 427 123 456'
-    
+
     Phony.format('959427123456', :format => :national).assert == '9 427 123 456'
     Phony.format('959427123456', :format => :local).assert == '427 123 456'
 
@@ -194,7 +197,7 @@ With forced trunk.
     Phony.format('41800112233', :format => :national).assert == '0800 112 233'
     Phony.format('41443643532', :format => :local).assert == '364 35 32'
     Phony.format('493038625454', :format => :local).assert == '386 25454'
-    
+
 #### Zimbabwe
 
 ##### Mobile numbers


### PR DESCRIPTION
Ghana has a trunk "0" trunk prefix.

See: https://en.wikipedia.org/wiki/Telephone_numbers_in_Ghana

![image](https://user-images.githubusercontent.com/127583/76909058-cb3ba900-68dc-11ea-8635-51720bbf632a.png)
