### PR TITLE
Add version.rb so that we can check the version at runtime

### DIFF
--- a/lib/phony.rb
+++ b/lib/phony.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'phony/version'
+
 # NOTE We use Kernel.load here, as it's possible to redefine Phony via Phony::Config.
 
 # Framework.

--- a/lib/phony/version.rb
+++ b/lib/phony/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Phony
+  VERSION = '2.18.12'
+end

--- a/phony.gemspec
+++ b/phony.gemspec
@@ -1,6 +1,8 @@
+require_relative 'lib/phony/version'
+
 Gem::Specification.new do |s|
   s.name = 'phony'
-  s.version = '2.18.12'
+  s.version = Phony::VERSION
   s.authors = ['Florian Hanke']
   s.email = 'florian.hanke+phony@gmail.com'
   s.homepage = 'http://github.com/floere/phony'

--- a/spec/lib/phony/version_spec.rb
+++ b/spec/lib/phony/version_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Phony::VERSION do
+  it { is_expected.to be }
+end


### PR DESCRIPTION
It is useful for monkey patches if you can check the gem version at runtime.

```ruby
# config/initializers/phony.rb
raise('Consider removing this patch') if Phony::VERSION != '2.18.12'

# Fix broken normalizing for japan. This change is based on the following pull request.
# ref: https://github.com/floere/phony/pull/457
Phony::CountryCodes.instance['81'].codes[0] = Phony::TrunkCode.new('0')
```

This sample code raises an exception when updating a gem and notices that the monkey patch is no longer needed.