### PR TITLE
Add support for 8-digit numbers in the Philippines

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -257,6 +257,7 @@ Phony.define do
     trunk('0') |
     # 7/10 digits for area code '2'.
     match(/\A(2)\d{10}\z/) >> split(10) |
+    match(/\A(2)\d{8}\z/) >> split(8) |
     one_of('2') >> split(7) |
     # mobile
     match(/\A([89]\d\d)\d{7}\z/) >> split(7) |

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -830,6 +830,8 @@ With regexp constraints.
       ['+63 920 123456', '+63 920 1234567']
     ]
 
+    Phony.assert.plausible?('+63 2 89889999')
+
 #### Qatar
 
     plausible? true: [

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -607,6 +607,7 @@ describe 'plausibility' do
       end
 
       it 'is correct for Philippine' do
+        Phony.plausible?('+63 2 89889999').should be_truthy
         Phony.plausible?('+63 976 1234567').should be_truthy # mobile phone with area code 9
         Phony.plausible?('+63 876 1234567').should be_truthy # mobile phone with area code 8
       end

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -613,6 +613,7 @@ describe 'country descriptions' do
     end
     describe 'Philippines' do
       it_splits '6321234567', ['63', '2', '1234567']
+      it_splits '63289889999', ['63', '2', '89889999']
       it_splits '6321234567890', ['63', '2', '1234567890']
       it_splits '632123456789012', ['63', '2', '123456789012']
       it_splits '639121234567', ['63', '912', '1234567']


### PR DESCRIPTION
Hi there. I'm working on a project which uses Phony. I had an issue validating 8-digit Philippine numbers and decided to help by adding them in.

It seems numbers under the area (code) 2 were migrated from a 7-digit format to 8 digits.

> Since October 6, 2019, all telephone numbers under area 2 had been migrated to eight digits as mandated by the National Telecommunications Commission per Memorandum Order No. 10-10-2017 in order to address the insufficient number of assignable local exchange codes. 

from [wikipedia](https://en.wikipedia.org/wiki/Telephone_numbers_in_the_Philippines#Fixed-line_area_codes).