### PR TITLE
Add support for 7-digit numbers in China

### DIFF
--- a/lib/phony/countries/china.rb
+++ b/lib/phony/countries/china.rb
@@ -28,5 +28,8 @@ Phony.define do
     one_of(service) >> split(8)   |
     one_of(mobile)  >> split(4,4) |
     one_of(ndcs)    >> split(4,4) |
-    fixed(3)        >> split(4,4)
+    fixed(3)        >> matched_split(
+        /\A\d{7}\z/ => [3,4],
+        /\A\d{8}\z/ => [4,4]
+    )
 end

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -360,6 +360,14 @@ http://www.khmerdigitalpost.com/mobile-operators-in-cambodia-by-2015/
 
     plausible? true: '+235 1234 5678'
 
+#### China
+
+    # Land lines can be 7 or 8 digits long.
+    Phony.refute.plausible?('+86 951 123 456') # Too short
+    Phony.assert.plausible?('+86 951 123 4567')
+    Phony.assert.plausible?('+86 755 8219 3447')
+    Phony.refute.plausible?('+86 755 8219 34471') # Too long
+
 #### Comoros
 
     plausible? true: [

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -215,6 +215,7 @@ describe 'country descriptions' do
     describe 'China' do
       it_splits '862112345678', ['86', '21', '1234', '5678']   # Shanghai
       it_splits '8675582193447', ['86', '755', '8219', '3447'] # Shenzhen
+      it_splits '869511234567', ['86', '951', '123', '4567']   # Yinchuan
 
       context 'mobile numbers' do
         %w{


### PR DESCRIPTION
Hi, I'm currently using Phony in my app and ran into an issue where 7 digit Chinese phones numbers were coming up as false in terms of plausibility. The number I was testing against was definitely real, so I dug in further.

Because of its rapid expansion in recent history, the [main article on Chinese numbers](https://en.wikipedia.org/wiki/Telephone_numbers_in_China) wasn't so clear on how long national numbers are. However, I did find proof of it in other places, such as here:
> Finally dial the phone number (6–8 digit telephone number).
- [Vonage](https://blog.vonageforhome.com/international-calling/how-to-call-china-from-the-u-s/)

Here is a completely random example of an in use [7 digit phone number](https://www.tripadvisor.com/Restaurant_Review-g494938-d12946784-Reviews-A_Ye-Yinchuan_Ningxia.html) that was incorrectly false in Phony before this PR.

This change now correctly takes into account both 7 and 8 digit phone numbers.