### PR TITLE
added specs & qed for belgium mobile numbers

### DIFF
--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -182,13 +182,18 @@ NDC with several subscriber number length.
     Phony.assert.plausible?('0032 3 241 11 32')
     Phony.assert.plausible?('0032 (0) 3 241 11 32')
     Phony.assert.plausible?('+32 455 12 34 56')
+    Phony.assert.plausible?('+32 456 12 34 56')
     Phony.assert.plausible?('+32 460 12 34 56')
     Phony.assert.plausible?('+32 465 12 34 56')
     Phony.assert.plausible?('+32 466 12 34 56')
+    Phony.assert.plausible?('+32 467 12 34 56')
     Phony.assert.plausible?('+32 468 12 34 56')
-    Phony.assert.plausible?('+32 471 12 34 56')
-    Phony.assert.plausible?('+32 481 12 34 56')
+    Phony.assert.plausible?('+32 470 12 34 56')
+    Phony.assert.plausible?('+32 479 12 34 56')
+    Phony.assert.plausible?('+32 480 12 34 56')
     Phony.assert.plausible?('+32 489 12 34 56')
+    Phony.assert.plausible?('+32 490 12 34 56')
+    Phony.assert.plausible?('+32 499 12 34 56')
 
 #### Benin
 

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -103,9 +103,16 @@ describe 'country descriptions' do
       it_splits '3295551914', ['32', '9', '555', '19', '14']   # Gent
       it_splits '3245551414', ['32', '4', '555', '14', '14']   # Liège
       it_splits '3216473200', ['32', '16', '47', '32', '00']   # Leuven
-      it_splits '32475279584', ['32', '475', '27', '95', '84'] # mobile
-      it_splits '32468279584', ['32', '468', '27', '95', '84'] # mobile (Telenet)
       it_splits '32455123456', ['32', '455', '12', '34', '56'] # mobile (Voo)
+      it_splits '32456123456', ['32', '456', '12', '34', '56'] # mobile (MobileViking)
+      it_splits '32460123456', ['32', '460', '12', '34', '56'] # mobile (Proximus)
+      it_splits '32465123456', ['32', '465', '12', '34', '56'] # mobile (Lycamobile)
+      it_splits '32466123456', ['32', '466', '12', '34', '56'] # mobile (Vectone)
+      it_splits '32467123456', ['32', '467', '12', '34', '56'] # mobile (Telenet)
+      it_splits '32468123456', ['32', '468', '12', '34', '56'] # mobile (Telenet)
+      it_splits '32475123456', ['32', '475', '12', '34', '56'] # mobile (Proximus)
+      it_splits '32485123456', ['32', '485', '12', '34', '56'] # mobile (Telenet)
+      it_splits '32495123456', ['32', '495', '12', '34', '56'] # mobile (Orange)
       it_splits '3270123123', ['32', '70', '123', '123']       # Bus Service?
       it_splits '3278123123', ['32', '78', '123', '123']       # National rate service
       it_splits '3290123123', ['32', '901', '23', '123']       # National rate service


### PR DESCRIPTION
Linked issue: https://github.com/floere/phony/issues/466

Looking into Belgian carriers attributed GSM ranges (https://en.wikipedia.org/wiki/Telephone_numbers_in_Belgium#Mobile_numbers),
it turns out '0411 22 33 44' is **_not_** be a plausible number
for only the following ranges have been attributed as of today:
```
0455: GSM. Range is owned by VOO; however subscriber may have been ported to another network
0456: GSM. Range is owned by MobileViking; however subscriber may have been ported to another network
0460: GSM. Range is owned by Proximus; however subscriber may have been ported to another network
0465: GSM. Range is owned by Lycamobile; however subscriber may have been ported to another network
0466: GSM. Range is owned by Vectone; however subscriber may have been ported to another network
0467: GSM. Range is owned by Telenet; however subscriber may have been ported to another network
0468: GSM. Range is owned by Telenet; however subscriber may have been ported to another network
047-: GSM. Range is owned by Proximus; however subscriber may have been ported to another network
048-: GSM Range is owned by Telenet (Base); however subscriber may have been ported to another network
049-: GSM Range is owned by Orange; however subscriber may have been ported to another network
```

👉 added a few specs & qed to complete the doc.
Fill free to close without merge if you wish ;)