### PR TITLE
Update numbering plan for Seatel (Cambodia)

### DIFF
--- a/lib/phony/countries/cambodia.rb
+++ b/lib/phony/countries/cambodia.rb
@@ -71,6 +71,7 @@ six_digit_extended_range_mobile_prefixes = [
 ]
 
 seven_digit_mobile_prefixes = [
+  '18', # Seatel
   '31', # Metfone
   '38', # CooTel
   '39', # EMAXX
@@ -83,10 +84,6 @@ seven_digit_mobile_prefixes = [
 
 variable_length_extended_range_mobile_prefixes = [
   '12' # Mobitel
-]
-
-mobile_prefixes_with_variable_length = [
-  '18' # Seatel
 ]
 
 six_digit_total_single_digit_fixed_line_prefixes = [
@@ -126,7 +123,6 @@ seven_digit_total_double_digit_fixed_line_prefixes = [
 
 Phony.define do
   country '855', trunk('0', :normalize => true) |
-                 one_of(mobile_prefixes_with_variable_length) >> matched_split(/^9/ => [3, 4], /^[2-8]/ => [3, 3]) |
                  one_of(variable_length_extended_range_mobile_prefixes) >> matched_split(/^1/ => [3, 4], /^[2-9]/ => [3, 3]) |
                  one_of(six_digit_mobile_prefixes)   >> matched_split(/^[2-9]/ => [3, 3]) |
                  one_of(six_digit_extended_range_mobile_prefixes) >> matched_split(/^[1-9]/ => [3, 3]) |

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -255,9 +255,6 @@ http://www.khmerdigitalpost.com/mobile-operators-in-cambodia-by-2015/
     Phony.assert.plausible?("+855383001801")    # CooTel (7 digit id)
     Phony.refute.plausible?("+85538300180")     # CooTel (too short)
 
-    Phony.assert.plausible?("+85518234567")     # Excell (6 digit id)
-    Phony.refute.plausible?("+855182345678")    # Excell (too long)
-
     Phony.assert.plausible?("+855882345678")    # Metfone (7 digit id)
     Phony.refute.plausible?("+85588234567")     # Metfone (too short)
     Phony.assert.plausible?("+855972345678")    # Metfone (7 digit id)
@@ -273,9 +270,7 @@ http://www.khmerdigitalpost.com/mobile-operators-in-cambodia-by-2015/
     Phony.assert.plausible?("+85510234567")     # Smart (6 digit id)
     Phony.refute.plausible?("+855102345678")    # Smart (too long)
 
-    Phony.assert.plausible?("+85518870054")     # Excell (6 digit id)
     Phony.assert.plausible?("+855189700541")    # Seatel (7 digit id)
-    Phony.refute.plausible?("+855188700545")    # Excell (too long)
     Phony.refute.plausible?("+85518970054")     # Seatel (too short)
 
     Phony.assert.plausible?("+855399999898")    # Kingtel  (7 digit id)


### PR DESCRIPTION
Updates Seatel (Cambodia to 7 digits)

https://en.wikipedia.org/wiki/Telephone_numbers_in_Cambodia

![IMG_1907 (1)](https://user-images.githubusercontent.com/127583/87114089-ea9a7f80-c299-11ea-96db-a8f1dc5e6cc6.PNG)
