### PR TITLE
Update ireland.rb

### DIFF
--- a/lib/phony/countries/ireland.rb
+++ b/lib/phony/countries/ireland.rb
@@ -9,14 +9,14 @@
 #
 # References:
 # http://www.comreg.ie/_fileupload/publications/ComReg03147.pdf (2003)
+# https://www.comreg.ie/media/dlm_uploads/2015/12/ComReg0804.pdf (2008)
 # http://www.comreg.ie/licensing_and_services/area_code_maps.552.1040.html
 # http://en.wikipedia.org/wiki/Telephone_numbers_in_the_Republic_of_Ireland
 #
 ndcs_with_5_subscriber_digits = [
-  '22', '23', '24', '25', '26', '27', '28', '29', # Mallow, Bandon, Youghal, Fermoy, Macroom, Bantry, Skibbereen, Kanturk
+  '22', '24', '25', '26', '27', '28', '29', # Mallow, Youghal, Fermoy, Macroom, Bantry, Skibbereen, Kanturk
   '402', # Arklow
   '404', # Wicklow
-  '43',  # Longford, Granard
   '47',  # Monaghan, Clones
   '48',  # Northern Ireland
   '502', # Portlaoise, Abbeyleix
@@ -24,12 +24,10 @@ ndcs_with_5_subscriber_digits = [
   '505', # Roscrea
   '506', # Tullamore
   '509', # Bin-
-  '52',  # Killenaule
   '54',  # Legacy Ferns, Enniscorthy
   '55',  # Legacy Gorey
   '62',  # Tipperary, Cashel
   '63',  # Charleville
-  '64',  # Killarney, Rathmore
   '67',  # Nenagh
   '68',  # Listowel
   '69',  # Newcastle West
@@ -47,15 +45,19 @@ ndcs_with_6_subscriber_digits = [
 ndcs_with_7_subscriber_digits = [
   '1',  # Dublin
   '21', # Cork, Coachford, Kinsale
+  '23', # Bandon
   '41', # Ardee
   '42', # Dundalk, Carrickmacross, Castleblaney
+  '43', # Longford, Granard
   '44', # Mullingar, Castlepollard, Tyrellspass
   '46', # Navan, Kells, Trim, Enfield, Edenderry
   '49', # Cavan, Cootehill, Oldcastle, Belturbet
+  '52', # Killenaule
   '53', # Wexford, Enniscorthy, Ferns, Gorey, Craanford
   '56', # Kilkenny, Castlecomer
   '58', # Dungarvan
   '59', # Carlow, Muine Bheag, Athy, Baltinglass
+  '64', # Killarney, Rathmore
   '65', # Ennistymon, Kilrush
   '66', # Tralee, Dingle, Killorglin, Cahirciveen
   '71', # Sligo, Manorhamilton, Carrick-on-Shannon


### PR DESCRIPTION
Some numbers in Ireland have moved from 5 -> 7 digits. The change took place over 6 months in 2009 and so I think it's now safe to treat only the new (7 digit) numbers as valid.

Also adding a new source, the updated doc from ComReg - https://www.comreg.ie/media/dlm_uploads/2015/12/ComReg0804.pdf