### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/phony.gemspec
+++ b/phony.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.version = '2.18.15'
   s.authors = ['Florian Hanke']
   s.email = 'florian.hanke+phony@gmail.com'
-  s.homepage = 'http://github.com/floere/phony'
+  s.homepage = 'https://github.com/floere/phony'
   s.license = 'MIT'
   s.platform = Gem::Platform::RUBY
   s.summary = 'Fast international phone number (E164 standard) normalizing, splitting and formatting.'


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/phony or some tools or APIs that use the gem's metadata.