### PR TITLE
Add 87 carrier code of Itelecom in Vietnam

### DIFF
--- a/lib/phony/countries/vietnam.rb
+++ b/lib/phony/countries/vietnam.rb
@@ -104,6 +104,7 @@ mobile = [
   '84', # Vinaphone
   '85', # Vinaphone
   '86', # Viettel
+  '87', # Itelecom
   '88', # Vinaphone
   '89',  # MobiFone,
   '90', # MobiFone


### PR DESCRIPTION
Add "87" carrier code of itelecom 
https://didong.itelecom.vn/