### PR TITLE
Allow 079 prefix for Rwanda phone numbers

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -432,9 +432,9 @@ Phony.define do
   # http://en.wikipedia.org/wiki/Telephone_numbers_in_Rwanda
   country '250',
     trunk('0') |
-    one_of('25')       >> split(7) | # Geographic, fixed
-    match(/^(7[238])/) >> split(7) | # Non-geographic, mobile
-    one_of('06')       >> split(6)   # Satellite
+    one_of('25')        >> split(7) | # Geographic, fixed
+    match(/^(7[2389])/) >> split(7) | # Non-geographic, mobile
+    one_of('06')        >> split(6)   # Satellite
 
   country '251', fixed(2) >> split(3, 4) # Ethiopia http://www.wtng.info/wtng-251-et.html
 

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -399,6 +399,12 @@ describe 'plausibility' do
                                                              '+507 6 123 4567',
                                                              '+507 2 123 456']
       it_is_correct_for 'Reunion / Mayotte (new)', :samples => '+262 295 276 964'
+      it_is_correct_for 'Rwanda', :samples => ['+250 72 1234567',
+                                               '+250 73 1234567',
+                                               '+250 78 1234567',
+                                               '+250 79 1234567',
+                                               '+250 25 1234567',
+                                               '+250 06 123456']
       it_is_correct_for 'Saint Helena', :samples => '+290  5134'
       it_is_correct_for 'Saint Pierre and Miquelon (Collectivité territoriale de la République française)', :samples => '+508  474 714'
       it_is_correct_for 'Salvador (El)', :samples => [

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -677,6 +677,7 @@ describe 'country descriptions' do
       it_splits '250781234567', ['250', '78', '1234567'] # mobile
       it_splits '250721234567', ['250', '72', '1234567'] # mobile
       it_splits '250731234567', ['250', '73', '1234567'] # mobile
+      it_splits '250791234567', ['250', '79', '1234567'] # mobile
       it_splits '250251234567', ['250', '25', '1234567'] # fixed
       it_splits '25006123456',  ['250', '06', '123456']  # fixed
     end


### PR DESCRIPTION
MTN Rwanda has introduced a new prefix - 079. 

Unfortunately, cannot find any official announcement for this except this twitter post: https://twitter.com/MTNRwanda/status/1358103403335933952