### PR TITLE
Fix mobile phone rules for Zambia

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -486,9 +486,9 @@ Phony.define do
   # http://www.wtng.info/wtng-260-zm.html
   # https://github.com/googlei18n/libphonenumber/
   country '260',
-    match(/^(9(5[034589]|[67]\d))/) >> split(6)   | # Mobile
-    match(/^(800)/)                 >> split(3,3) | # Toll free
-    match(/^(21[1-8])/)             >> split(6)     # Fixed
+    match(/^([79][5678]\d)/) >> split(6)   | # Mobile
+    match(/^(800)/)          >> split(3,3) | # Toll free
+    match(/^(21[1-8])/)      >> split(6)     # Fixed
 
   # Madagascar http://www.wtng.info/wtng-261-mg.html
   # http://www.itu.int/oth/T020200007F/en

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -255,7 +255,7 @@ describe 'plausibility' do
       end
       # it_is_correct_for 'Gabonese Republic', :samples => [
       #   '+241 1 627 739',
-      #   '+241 12 34 56 78', 
+      #   '+241 12 34 56 78',
       # ]
       it_is_correct_for 'Gambia', :samples => '+220  989 5148'
       it_is_correct_for 'Germany', :samples => [
@@ -568,6 +568,9 @@ describe 'plausibility' do
                                               '+967 58 1234']
       it 'is correct for Zambia' do
         Phony.plausible?('+260 211 123456').should be_truthy  # Fixed
+        Phony.plausible?('+260 761 123456').should be_truthy  # Mobile
+        Phony.plausible?('+260 772 123456').should be_truthy  # Mobile
+        Phony.plausible?('+260 783 123456').should be_truthy  # Mobile
         Phony.plausible?('+260 955 123456').should be_truthy  # Mobile
         Phony.plausible?('+260 967 123456').should be_truthy  # Mobile
         Phony.plausible?('+260 978 123456').should be_truthy  # Mobile


### PR DESCRIPTION
According to https://www.itu.int/oth/T02020000E8/en, mobile phone numbers can start with 7 as well as 9. I've tried to update the validation rules without breaking anything. 