### PR TITLE
Add international Freephone Service Support

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -993,7 +993,11 @@ Phony.define do
   country '698', todo # -
   country '699', todo # -
 
-  country '800', todo # International Freephone Service
+  # International Freephone Service
+  # https://www.itu.int/en/ITU-T/inr/unum/Pages/uifn.aspx
+  country '800',
+    none >> split(8)
+
   country '801', todo # -
   country '802', todo # -
   country '803', todo # -

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -1429,6 +1429,10 @@ describe 'country descriptions' do
         it_splits  number, ['263', prefix, '234', '5678']
       end
     end
+
+    describe 'Universal International Freephone' do
+      it_splits '80012345678', ['800', false, '12345678']
+    end
   end
 
 end


### PR DESCRIPTION
A customer was trying to use an international freephone number for their support number, but phony did not validated this phone number. I looked up the rules, fortunately the ITU has a nice document describing the number format: https://www.itu.int/en/ITU-T/inr/unum/Pages/uifn.aspx#format

And it ends up being real simple ... +800 "country" code + 8 local digits, so we can split this easily.

If any more tests are needed, let me know and I will add this.