### PR TITLE
Add trunk prefix and improve formatting for Zambia

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -486,8 +486,10 @@ Phony.define do
   # Zambia
   # http://www.wtng.info/wtng-260-zm.html
   # https://github.com/googlei18n/libphonenumber/
+  # https://en.wikipedia.org/wiki/Telephone_numbers_in_Zambia
   country '260',
-    match(/^([79][5678]\d)/) >> split(6)   | # Mobile
+    trunk('0') |
+    match(/^(76|77|95|96|97)/) >> split(3, 4) | # Mobile
     match(/^(800)/)          >> split(3,3) | # Toll free
     match(/^(21[1-8])/)      >> split(6)     # Fixed
 

--- a/qed/format.md
+++ b/qed/format.md
@@ -199,6 +199,11 @@ With forced trunk.
     Phony.format('41443643532', :format => :local).assert == '364 35 32'
     Phony.format('493038625454', :format => :local).assert == '386 25454'
 
+#### Zambia
+
+    Phony.format('260970212078').assert == '+260 97 021 2078'
+    Phony.format('260970212078', :format => :national).assert == '097 021 2078'
+
 #### Zimbabwe
 
 ##### Mobile numbers

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -568,12 +568,12 @@ describe 'plausibility' do
                                               '+967 58 1234']
       it 'is correct for Zambia' do
         Phony.plausible?('+260 211 123456').should be_truthy  # Fixed
-        Phony.plausible?('+260 761 123456').should be_truthy  # Mobile
-        Phony.plausible?('+260 772 123456').should be_truthy  # Mobile
-        Phony.plausible?('+260 783 123456').should be_truthy  # Mobile
-        Phony.plausible?('+260 955 123456').should be_truthy  # Mobile
-        Phony.plausible?('+260 967 123456').should be_truthy  # Mobile
-        Phony.plausible?('+260 978 123456').should be_truthy  # Mobile
+        Phony.plausible?('+260 96 512 4567').should be_truthy # MTN Mobile
+        Phony.plausible?('+260 97 712 3456').should be_truthy # Airtel Mobile
+        Phony.plausible?('+260 95 512 4567').should be_truthy # Zamtel Mobile
+        Phony.plausible?('+260 96 512 456').should be_falsy   # MTN Mobile (Too short)
+        Phony.plausible?('+260 97 812 345').should be_falsy   # Airtel Mobile (Too short)
+        Phony.plausible?('+260 95 512 345').should be_falsy   # Zamtel Mobile (Too short)
         Phony.plausible?('+260 800 123 456').should be_truthy # Toll free
       end
       it_is_correct_for 'Zimbabwe', :samples => [['+263 2582 123 456', '+263 2582 123'],

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -851,9 +851,9 @@ describe 'country descriptions' do
     end
     describe 'Zambia' do
       it_splits '260211123456', ['260', '211', '123456']     # Fixed
-      it_splits '260955123456', ['260', '955', '123456']     # Mobile
-      it_splits '260967123456', ['260', '967', '123456']     # Mobile
-      it_splits '260978123456', ['260', '978', '123456']     # Mobile
+      it_splits '260955123456', ['260', '95', '512', '3456'] # Mobile
+      it_splits '260967123456', ['260', '96', '712', '3456'] # Mobile
+      it_splits '260978123456', ['260', '97', '812', '3456'] # Mobile
       it_splits '260800123456', ['260', '800', '123', '456'] # Toll free
     end
     describe 'New Zealand' do
@@ -1433,7 +1433,7 @@ describe 'country descriptions' do
     describe 'Universal International Freephone' do
       it_splits '80012345678', ['800', false, '12345678']
     end
-    
+
     describe 'Shared-Cost Service' do
       it_splits '80812345678', ['808', false, '12345678']
     end


### PR DESCRIPTION
Based on new information:

https://en.wikipedia.org/wiki/Telephone_numbers_in_Zambia#List_of_area_codes_in_Zambia

* Mobile numbers have 9 digits (excluding country code)
* A trunk prefix of 0 is used for local dialing