### PR TITLE
Add 469 as valid mobile number for Belgium

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -96,15 +96,16 @@ Phony.define do
   # Belgium.
   #
   # http://en.wikipedia.org/wiki/Telephone_numbers_in_Belgium
+  # https://www.bipt.be/operators/publication/national-numbering-plan
   #
   country '32', trunk('0') |
-                match(/^(7[08])\d+$/)       >> split(3,3)   | # Premium and national rate Services
-                match(/^(800|90\d)\d+$/)    >> split(2,3)   | # Toll free service and premium numbers
-                match(/^(46[05678])\d{6}$/) >> split(2,2,2) | # Mobile (Lycamobile, Telenet, Join Experience, Proximus 0460)
-                match(/^(4[789]\d)\d{6}$/)  >> split(2,2,2) | # Mobile
-                match(/^(45[56])\d{6}$/)    >> split(2,2,2) | # Mobile Vikings and Voo
-                one_of('2','3','4','9')     >> split(3,2,2) | # Short NDCs
-                fixed(2)                    >> split(2,2,2)   # 2-digit NDCs
+                match(/^(7[08])\d+$/)        >> split(3,3)   | # Premium and national rate Services
+                match(/^(800|90\d)\d+$/)     >> split(2,3)   | # Toll free service and premium numbers
+                match(/^(46[056789])\d{6}$/) >> split(2,2,2) | # Mobile (Lycamobile, Telenet, Join Experience, Proximus 0460)
+                match(/^(4[789]\d)\d{6}$/)   >> split(2,2,2) | # Mobile
+                match(/^(45[56])\d{6}$/)     >> split(2,2,2) | # Mobile Vikings and Voo
+                one_of('2','3','4','9')      >> split(3,2,2) | # Short NDCs
+                fixed(2)                     >> split(2,2,2)   # 2-digit NDCs
 
   # France.
   #

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -188,6 +188,7 @@ NDC with several subscriber number length.
     Phony.assert.plausible?('+32 466 12 34 56')
     Phony.assert.plausible?('+32 467 12 34 56')
     Phony.assert.plausible?('+32 468 12 34 56')
+    Phony.assert.plausible?('+32 469 12 34 56')
     Phony.assert.plausible?('+32 470 12 34 56')
     Phony.assert.plausible?('+32 479 12 34 56')
     Phony.assert.plausible?('+32 480 12 34 56')

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -110,6 +110,7 @@ describe 'country descriptions' do
       it_splits '32466123456', ['32', '466', '12', '34', '56'] # mobile (Vectone)
       it_splits '32467123456', ['32', '467', '12', '34', '56'] # mobile (Telenet)
       it_splits '32468123456', ['32', '468', '12', '34', '56'] # mobile (Telenet)
+      it_splits '32469123456', ['32', '469', '12', '34', '56'] # mobile ()
       it_splits '32475123456', ['32', '475', '12', '34', '56'] # mobile (Proximus)
       it_splits '32485123456', ['32', '485', '12', '34', '56'] # mobile (Telenet)
       it_splits '32495123456', ['32', '495', '12', '34', '56'] # mobile (Orange)


### PR DESCRIPTION
The 469 prefix is now valid for mobile phone numbers according to the Belgium [national numbering plan](https://www.bipt.be/operators/publication/national-numbering-plan).