### PR TITLE
Update samoa numbers

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -977,7 +977,7 @@ Phony.define do
               /\A800\d+\z/ => [3,3], # freephone
               /\A830\d+\z/ => [3,3], # shared cost
               /\A60\d+\z/ => [3,3], # wireless geographic
-              /\A(72|75|76|77)\d+\z/ => [3,4], # mobile
+              /\A(71|72|75|76|77)\d+\z/ => [3,4], # mobile
               /\A84\d+\z/ => [3,4], # wireless geographic
               /\A\d+\z/ => [2,3] # geographic
           )

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -892,6 +892,16 @@ With regexp constraints.
       '+40 249 123 123'
     ]
 
+#### Samoa (Independent State of)
+
+    Phony.assert.plausible?('+685 800 123')
+    Phony.assert.plausible?('+685 61 123')
+    Phony.assert.plausible?('+685 711 2345')
+    Phony.assert.plausible?('+685 721 2345')
+    Phony.assert.plausible?('+685 830 123')
+    Phony.assert.plausible?('+685 601 234')
+    Phony.assert.plausible?('+685 841 2345')
+
 #### Russia
 
     Phony.assert.plausible?('+7 800 2000 600')

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -1235,6 +1235,7 @@ describe 'country descriptions' do
     describe 'Samoa (Independent State of)' do
       it_splits '685800123', ['685', false, '800', '123']
       it_splits '68561123', ['685', false, '61', '123']
+      it_splits '6857112345', ['685', false, '711', '2345']
       it_splits '6857212345', ['685', false, '721', '2345']
       it_splits '685830123', ['685', false, '830', '123']
       it_splits '685601234', ['685', false, '601', '234']


### PR DESCRIPTION
This PR addresses issue #496.

@floere Since I didn't find any online reference stating that Samoa numbers can start with "71", I got in touch with Samoa's Vodafone customer service and they confirmed this in the attached email.
[Vodafone Samoa Website - Enquiry.txt](https://github.com/floere/phony/files/8531270/Vodafone.Samoa.Website.-.Enquiry.txt)
