### PR TITLE
Fix for Rome (Italy) numbers

### DIFF
--- a/lib/phony/countries/italy.rb
+++ b/lib/phony/countries/italy.rb
@@ -272,7 +272,12 @@ Phony.define do
   country '39', trunk('', normalize: false) |
                 one_of(*service)     >> split(3,3) |
                 one_of(*mobile)      >> split(3,4,-1..1) |
-                one_of(*ndcs_2digit) >> split(4, 2..4) |
+                one_of(*ndcs_2digit) >> matched_split(
+                  /\A\d{5}\z/ => [5],
+                  /\A\d{6}\z/ => [4,2],
+                  /\A\d{7}\z/ => [4,3],
+                  /\A\d{8}\z/ => [4,4],
+                ) |
                 one_of(*ndcs_3digit) >> matched_split(
                   /^1\d{6}$/ => [7],
                   /^1\d{7}$/ => [8],

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -280,7 +280,8 @@ describe 'plausibility' do
       it_is_correct_for 'Guinea-Bissau', :samples => '+245 44 728 6998'
       it_is_correct_for 'Guyana', :samples => '+592 263 1234'
       it_is_correct_for 'Honduras (Republic of)', :samples => '+504 12 961 637'
-      it_is_correct_for 'Italy', :samples => ['+39 0574 1234']
+      it_is_correct_for 'Italy', :samples => ['+39 0574 1234',
+                                              '+39 06 49911']
       it_is_correct_for 'Iraq', :samples => ['+964 1 123 4567',
                                              '+964 21 113 456',
                                              '+964 71 1234 5678']

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -460,8 +460,9 @@ describe 'country descriptions' do
       it_splits '3934869528123',['39', '348', '695', '2812', '3']  # Mobile (8-digit subscriber no - new)
       it_splits '393357210488', ['39', '335', '721', '0488'] # Mobile
       it_splits '393248644272', ['39', '324', '864', '4272'] # Mobile
-      it_splits '3906123412',   ['39', '06', '1234', '12'] # Roma 6 digit
-      it_splits '39061234123',  ['39', '06', '1234', '123'] # Roma 7 digit
+      it_splits '390612341',    ['39', '06', '12341']        # Roma 5 digit
+      it_splits '3906123412',   ['39', '06', '1234', '12']   # Roma 6 digit
+      it_splits '39061234123',  ['39', '06', '1234', '123']  # Roma 7 digit
       it_splits '390612341234', ['39', '06', '1234', '1234'] # Roma 8 digit
       it_splits '3902888388',   ['39', '02', '8883', '88'] # Milano 6 digit
       it_splits '39028883888',  ['39', '02', '8883', '888'] # Milano 7 digit


### PR DESCRIPTION
This fixes the `plausible?` check and formatting of short Italian / Rome numbers.

For example, "+39 06 49911" is the phone number from a University in Rome (see https://www2.uniroma1.it/eletel/telefoni/default.php).

