### PR TITLE
Add support for Italian free of charge numbers

### DIFF
--- a/lib/phony/countries/italy.rb
+++ b/lib/phony/countries/italy.rb
@@ -268,11 +268,18 @@ service = [ # Not exhaustive.
  '1530'
 ]
 
+free_of_charge_services = [ # Not exhaustive.
+  '800',
+  '803'
+]
+
 Phony.define do
   # Note: The 0 does not count towards NDC number length.
   country '39', trunk('', normalize: false) |
                 one_of(*service)     >> split(3,3) |
                 one_of(*mobile)      >> split(3,4,-1..1) |
+                match(/^(800)\d{6}$/) >> split(6) | # 3-6, Special handling for 800 numbers.
+                match(/^(803)\d{3}$/) >> split(3) | # 3-3, Special handling for 803 numbers.
                 one_of(*ndcs_1digit) >> matched_split(
                   /\A\d{5}\z/ => [5],
                   /\A\d{6}\z/ => [4,2],

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -621,6 +621,12 @@ describe 'plausibility' do
         Phony.plausible?('+39 06 4991').should be_falsy
         Phony.plausible?('+39 06 49911').should be_truthy
         Phony.plausible?('+39 06 499112').should be_truthy
+
+        Phony.plausible?('+39 800 081631').should be_truthy
+        Phony.plausible?('+39 800 0816311').should be_falsy
+
+        Phony.plausible?('+39 803 08163').should be_falsy
+        Phony.plausible?('+39 803 081').should be_truthy
       end
 
       it 'is correct for Russia' do


### PR DESCRIPTION
According to https://www.itu.int/dms_pub/itu-t/oth/02/02/T020200006B0001PDFE.pdf Italy supports both the 800 and 803 prefix for free-of-charge service numbers.

For 800 numbers, numbers have both a maximum and minimum length 0f 9. For 803 numbers, numbers have both a maximum and minimum length of 6.

I've needed to special case these both (similar to how united kingdom handles 500 & 800) numbers to ensure that these criteria are met.

One quirk that this leads to is that there is `free_of_charge_services` array which is defined but not used but I think this still has value for describing why these numbers are special.