### PR TITLE
Burkina Faso Trunk Prefix and Splitting

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -363,7 +363,15 @@ Phony.define do
     trunk('', :normalize => false) |
     fixed(2) >> split(2,2,2,2)
 
-  country '226', none >> split(4,4) # Burkina Faso http://www.wtng.info/wtng-226-bf.html
+  # Burkina Faso
+  # http://www.wtng.info/wtng-226-bf.html
+  # https://en.wikipedia.org/wiki/Telephone_numbers_in_Burkina_Faso
+  #
+  # There is no trunk code for this country and several of the mobile prefixes start with 0
+  country '226',
+    trunk('', normalize: false) |
+    none >> split(2,2,2,2)
+
   country '227', none >> split(4,4) # Niger http://www.wtng.info/wtng-227-ne.html
   country '228', none >> split(4,4) # Togolese Republic http://www.wtng.info/wtng-228-tg.html
   country '229', none >> split(4,4) # Benin http://www.itu.int/oth/T0202000017/en

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -871,7 +871,7 @@ describe 'country descriptions' do
       it_splits '6737932744', %w(673 7 932 744)
     end
     describe 'Burkina Faso' do
-      it_splits '22667839323', ['226', false, '6783', '9323']
+      it_splits '22667839323', ['226', false, '67', '83', '93', '23']
     end
     describe 'Burundi' do
       it_splits '25712345678', ['257', false, '1234', '5678']


### PR DESCRIPTION
Hi Florian :wave:

I noticed while working with the gem that Burkina Faso mobile numbers are not supposed to have a trunk prefix, and also that the splitting should be in the XX XX XX XX format, rather than XXXX XXXX.

For instance numbers with a `0` (zero) after the country code (`226`) passed though `PhonyRails` failed validations as the zero was seen as trunk and removed.

This changed should be fixing that.

Please let me know if there should be more specs and/or QED tests (I'm not familiar with the latter) :slightly_smiling_face: