### PR TITLE
updates kiribati phone length from 5 to 8

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -992,7 +992,7 @@ Phony.define do
               /\A\d+\z/ => [2,3] # geographic
           )
 
-  country '686', none >> split(2,3) # Kiribati (Republic of) http://www.wtng.info/wtng-686-ki.html
+  country '686', none >> split(8) # Kiribati (Republic of) https://www.numberingplans.com/?page=plans&sub=phonenr&alpha_2_input=KI
   country '687', none >> split(3,3) # New Caledonia (Territoire français d'outre-mer) http://www.wtng.info/wtng-687-nc.html
   country '688', none >> split(5) # Tuvalu http://www.wtng.info/wtng-688-tv.html
   country '689', none >> split(2,2,2,2) # French Polynesia (Territoire français d'outre-mer) http://www.wtng.info/wtng-689-pf.html

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -293,7 +293,7 @@ describe 'plausibility' do
                                              '+964 71 1234 5678']
 
 
-      it_is_correct_for 'Kiribati (Republic of)', :samples => '+686  31993'
+      it_is_correct_for 'Kiribati (Republic of)', :samples => '+686  34814527'
       it_is_correct_for "Democratic People's Republic of Korea", :samples => ['+850 2 123 45',
                                                                               '+850 2 123 456 789',
                                                                               '+850 2 381 2356',

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -1013,7 +1013,7 @@ describe 'country descriptions' do
       it_splits '96287901456', %w(962 8790 1456)
     end
     describe 'Kiribati (Republic of)' do
-      it_splits '68634814', ['686', false, '34', '814']
+      it_splits '68634814527', ['686', false, '34814527']
     end
     describe "Democratic People's Republic of Korea" do
       it_splits '850212345', %w(850 2 123 45)


### PR DESCRIPTION
Hey! 

It seems Kiribati phone number were updated few years ago and now their length is not 5, it's 8. 

I've updated the code according to my understanding of it (I'm not sure whether you want to take into account prefixes of different mobile services) and fixed it in our app. Let me know if anything is missing or you want to change something.

Thanks,
Serge