### PR TITLE
Adding support for Norfolk Island

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -920,7 +920,14 @@ Phony.define do
           )
 
   country '671', todo # Spare code
-  country '672', todo # Australian External Territories
+
+  # Australian External Territories https://en.wikipedia.org/wiki/Telephone_numbers_in_Norfolk_Island
+  # Norfolk Island
+  country '672',
+          fixed(1) >> split(2,3) |
+          match(/^(2\d\d\d\d).+$/) >> split(3) | # Fixed
+          match(/^(5\d\d\d\d).+$/) >> split(3) # Mobile
+
   country '673', fixed(1) >> split(3, 3) # Brunei Darussalam http://www.wtng.info/wtng-673-bn.html
   country '674', none >> split(3, 4) # Nauru (Republic of) http://www.wtng.info/wtng-674-nr.html
 

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -593,6 +593,10 @@ describe 'country descriptions' do
       it_splits '31222123456', ['31', '222', '123', '456']
       it_splits '3197012345678', ['31', '970', '1234', '5678'] # machine-to-machine
     end
+    describe 'Norfolk Island' do
+      it_splits '672321234', ['672', '3', '21', '234'] # fixed
+      it_splits '672351234', ['672', '3', '51', '234'] # mobile
+    end
     describe 'Norway' do
       it_splits '4721234567', ['47',false,'21','23','45','67']
       it_splits '4731234567', ['47',false,'31','23','45','67']


### PR DESCRIPTION
Adding support for Norfolk Island numbers, which should fix the `plausible?` check.

Example: 
* "+672 3 21234" should return true for `Phony.plausible?`, as per https://en.wikipedia.org/wiki/Telephone_numbers_in_Norfolk_Island format.