### PR TITLE
Update Mauritius in order to support mobile and landlines

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -104,7 +104,7 @@ For example, when just loading the NANP CC, the retained memory usage is ~63kB.
 
 h2. List of Handled Countries
 
-Mildly unmaintained list: Abhas, Afghan, Algerian, Argentina, Austrian, Australian, Azerbaijani, Belgian, Brazilian, Cambodian, Chilean, Chinese, Croatian, Cuban, Cypriot, Czech, Danish, Dutch, Egyptian, El Salvadorian, Estonian, French, German, Ghanan, Gibraltar, Greek, Haiti, Hong Kong, Hungarian, Indian, Iran, Irish, Israel, Italian, Japanese, Kazakh, Liberian, Lithuanian, Luxembourgian, Malaysian, Malta, Mexican, Monaco, Morocco, New Zealand, Nigerian, Norwegian, Peruvian, Polish, Romanian, Russian, Rwandan, Seychelles, Singapore, Slovakian, South African, South Korean, South Osetian, Spanish, Sri Lankan, Sudan, Swedish, Swiss, Thailand, Tunisian, Turkish, Liechtenstein, UK, US, Venezuelan, Vietnamese, and Zambian numbers.
+Mildly unmaintained list: Abhas, Afghan, Algerian, Argentina, Austrian, Australian, Azerbaijani, Belgian, Brazilian, Cambodian, Chilean, Chinese, Croatian, Cuban, Cypriot, Czech, Danish, Dutch, Egyptian, El Salvadorian, Estonian, French, German, Ghanan, Gibraltar, Greek, Haiti, Hong Kong, Hungarian, Indian, Iran, Irish, Israel, Italian, Japanese, Kazakh, Liberian, Lithuanian, Luxembourgian, Malaysian, Malta, Mauritian, Mexican, Monaco, Morocco, New Zealand, Nigerian, Norwegian, Peruvian, Polish, Romanian, Russian, Rwandan, Seychelles, Singapore, Slovakian, South African, South Korean, South Osetian, Spanish, Sri Lankan, Sudan, Swedish, Swiss, Thailand, Tunisian, Turkish, Liechtenstein, UK, US, Venezuelan, Vietnamese, and Zambian numbers.
 
 h2. Proud Sponsors
 

--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -376,7 +376,16 @@ Phony.define do
   country '228', none >> split(4,4) # Togolese Republic http://www.wtng.info/wtng-228-tg.html
   country '229', none >> split(4,4) # Benin http://www.itu.int/oth/T0202000017/en
 
-  country '230', none >> split(4,4) # Mauritius http://www.wtng.info/wtng-230-mu.html
+  # Mauritius
+  # http://www.wtng.info/wtng-230-mu.html
+  # https://en.wikipedia.org/wiki/Telephone_numbers_in_Mauritius
+  #
+  # There is no trunk code for this country.
+  country '230',
+    none >> matched_split(
+      /^5\d{7}$/ => [1,3,4], # Mobile
+      /^[246]\d{6}$/ => [3,4], # Landline
+    )
 
   # Liberia
   # https://www.numberingplans.com/?page=plans&sub=phonenr&alpha_2_input=LR

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -694,6 +694,15 @@ Mobile.
     Phony.refute.plausible?('+60 14 1234 12')     # too short
     Phony.refute.plausible?('+60 14 1234 12345')  # too long
 
+#### Mauritius
+
+    Phony.assert.plausible?('+230 5 123 4567') # mobile number
+    Phony.assert.plausible?('+230 260 0070') # landline
+    Phony.refute.plausible?('+230 2 123 4567') # too long for landline
+    Phony.refute.plausible?('+230 212 456') # too short for landline
+    Phony.refute.plausible?('+230 5 1234 5678') # too long for mobile
+    Phony.refute.plausible?('+230 5 123 567') # too short for mobile
+
 #### Mexico
 
     Phony.assert.plausible?('+52 1 55 1212 1212')

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -355,7 +355,8 @@ describe 'plausibility' do
       it_is_correct_for 'Marshall Islands (Republic of the)', :samples => '+692  372 7183'
       it_is_correct_for 'Martinique (French Department of)', :samples => '+596 596 123 456'
       it_is_correct_for 'Mauritania', :samples => '+222  1234 5678'
-      it_is_correct_for 'Mauritius', :samples => '+230  5695 2277'
+      it_is_correct_for 'Mauritius', :samples => ['+230  5 695 2277',
+                                                  '+230  260 0070']
       it_is_correct_for 'Micronesia (Federated States of)', :samples => '+691  766 7914'
       it_is_correct_for 'Moldova', :samples => ['+373 800 123 45',
                                                 '+373 22 123 345',

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -1090,7 +1090,8 @@ describe 'country descriptions' do
       it_splits '22212345678', ['222', false, '1234', '5678']
     end
     describe 'Mauritius' do
-      it_splits '23059518919', ['230', false, '5951', '8919']
+      it_splits '23059518919', ['230', false, '5', '951', '8919']
+      it_splits '2302600070', ['230', false, '260', '0070']
     end
     describe 'Micronesia (Federated States of)' do
       it_splits '6911991754', ['691', false, '199', '1754']


### PR DESCRIPTION
Hi Florian!

This PR should fix an issue with Mauritian numbers.  As per [Wikipedia](https://en.wikipedia.org/wiki/Telephone_numbers_in_Mauritius), Mauritian mobile numbers consist of 8 digits (always beginning with `5`), and landline numbers consist of 7 digits (always beginning with `2`, `4` or `6`).  Before this PR, all Mauritian landline numbers would unfortunately fail validation.

Please let me know if any additional work is required :-)

Thanks!