### PR TITLE
Fix trunk prefix for Laos

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -1079,6 +1079,7 @@ Phony.define do
 
   # Lao People's Democratic Republic http://www.wtng.info/wtng-856-la.html, https://www.numberingplans.com
   country '856',
+          trunk('0') |
           one_of('30') >> split(3,4) | # geographic
           one_of('20') >> split(4,4) | # mobile
           fixed(2) >> split(3,3) # geographic

--- a/qed/format.md
+++ b/qed/format.md
@@ -120,6 +120,11 @@ http://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers
     Phony.format('393333337647', :format => :national).assert == '333 333 7647'
     Phony.format('390108480161', :format => :national).assert == '010 8480161'
 
+#### Laos
+
+    Phony.format('8562092960311', :format => :international).assert == '+856 20 9296 0311'
+    Phony.format('8562092960311', :format => :national).assert == '020 9296 0311'
+
 #### Liechtenstein
 
     Phony.format('4233841148', :format => :international_relative).assert == '00423 384 11 48'


### PR DESCRIPTION
Laos has a trunk prefix (0)

https://en.wikipedia.org/wiki/Telephone_numbers_in_Laos
http://www.wtng.info/wtng-856-la.html