### PR TITLE
Update landlines phones format for brazilian numbers

### DIFF
--- a/lib/phony/countries/brazil.rb
+++ b/lib/phony/countries/brazil.rb
@@ -4,7 +4,7 @@
 #
 #
 # NDC Reference
-# http://www.anatel.gov.br/hotsites/CodigosNacionaisLocalidade/TelefoneCelular-CodigosDeArea.htm
+# https://www.gov.br/anatel/pt-br/regulado/numeracao/plano-de-numeracao-brasileiro
 
  # 11 #Sao Paulo
  # 12 #Sao Paulo
@@ -99,7 +99,7 @@ special_numbers_4 = %w{ 3003 4003 4004 4020 }
 Phony.define do
   country '55',
     match(/^#{ndcs}9\d{8}$/)     >> split(5,4) |
-    match(/^#{ndcs}\d{8}$/)      >> split(4,4) |
+    match(/^#{ndcs}[2-5]\d{7}$/) >> split(4,4) |
     one_of(special_numbers_3_4)  >> split(3,4) |
     one_of(special_numbers_4)    >> split(4) |
     one_of(service)              >> split(3) |

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -51,6 +51,14 @@ describe 'plausibility' do
       it_is_correct_for 'Bosnia and Herzegovina', :samples => ['+387 66 666 666',
                                                                '+387 37 123 456',
                                                                '+387 33 222 111']
+      it 'is correct for Brasil' do
+        Phony.plausible?('+55 67 998280912').should be_truthy
+        Phony.plausible?('+55 67 98280912').should be_falsey
+        Phony.plausible?('+55 11 12345678').should be_falsey
+        Phony.plausible?('+55 11 123456789').should be_falsey
+        Phony.plausible?('+55 11 023456789').should be_falsey
+        Phony.plausible?('+55 11 22345678').should be_truthy
+      end
       it 'is correct for Bulgaria' do
           Phony.plausible?('+359 2 1234567').should be_truthy
           Phony.plausible?('+359 30 12345').should be_truthy

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -147,9 +147,9 @@ describe 'country descriptions' do
     end
 
     describe 'Brazil' do
-      it_splits '551112341234', ['55', '11', '1234', '1234']
+      it_splits '551122341234', ['55', '11', '2234', '1234']
       it_splits '5511981231234', ['55', '11', '98123', '1234'] # São Paulo's 9 digits mobile
-      it_splits '552181231234', ['55', '21', '8123', '1234']
+      it_splits '5521981231234', ['55', '21', '98123', '1234']
       it_splits '5521981231234', ['55', '21', '98123', '1234'] # Rio de Janeiro's 9 digits mobile
       it_splits '551931311234', ['55', '19', '3131', '1234']
       it_splits '5531991311234', ['55', '31', '99131', '1234'] # Belo Horizonte's 9th digit
@@ -157,6 +157,7 @@ describe 'country descriptions' do
       it_splits '5579991311234', ['55', '79', '99131', '1234'] # Sergipe's 9th digit
       it_splits '5547991311234', ['55', '47', '99131', '1234'] # Santa Catarina's 9th digit
       it_splits '5541991311234', ['55', '41', '99131', '1234'] # Parana's 9th digit
+      it_splits '556734212121', ['55', '67', '3421', '2121']
 
       context 'mobile numbers' do
         %w{

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -149,7 +149,6 @@ describe 'country descriptions' do
     describe 'Brazil' do
       it_splits '551122341234', ['55', '11', '2234', '1234']
       it_splits '5511981231234', ['55', '11', '98123', '1234'] # São Paulo's 9 digits mobile
-      it_splits '5521981231234', ['55', '21', '98123', '1234']
       it_splits '5521981231234', ['55', '21', '98123', '1234'] # Rio de Janeiro's 9 digits mobile
       it_splits '551931311234', ['55', '19', '3131', '1234']
       it_splits '5531991311234', ['55', '31', '99131', '1234'] # Belo Horizonte's 9th digit


### PR DESCRIPTION
### Explanation
- Landline phones in Brazil always have 8 digits and always starts with the digit 2, 3, 4 or 5.
- Currently we don't have anymore no phone numbers with local part starting with 6, 7 or 8.
- Current Phony specs accepts, for example `+55 11 1111 1111` which is an impossible number for us.
- I also updated the reference link within `lib/phony/countries/brazil.rb` file, because the old site isn´t working anymore.

### References
- https://en.wikipedia.org/wiki/Telephone_numbers_in_Brazil
- https://www.gov.br/anatel/pt-br/regulado/numeracao/tabela-servico-telefonico-fixo-comutado
