### PR TITLE
Allow Vietnamese 1900 numbers to be validated

### DIFF
--- a/lib/phony/countries/vietnam.rb
+++ b/lib/phony/countries/vietnam.rb
@@ -127,6 +127,9 @@ Phony.define do
     one_of(ndcs_with_7_subscriber_digits) >> split(3,4) |
     one_of(ndcs_with_8_subscriber_digits) >> split(4,4) |
     one_of(mobile_with_trunk)             >> split(5..8)|
+    one_of('1900')                        >> matched_split(
+      /\A\d{4}\z/ => [4],
+      /\A\d{6}\z/ => [6]) | # Premium rate
     # Govt reserved
     fixed(80)                             >> split(5)   |
     fixed(69)                             >> split(1,5)

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -987,8 +987,12 @@ With regexp constraints.
     Phony.assert.plausible?('+84 24 1234 5678')
     Phony.assert.plausible?('+84 091 123-4567')
     Phony.assert.plausible?('+84 034 123456')
+    Phony.assert.plausible?('+84 1900 1212')
+    Phony.assert.plausible?('+84 1900 541234')
     Phony.refute.plausible?('+84 1 1234') # too short
     Phony.refute.plausible?('+84 12 3456 7891 0111213') # too long
+    Phony.refute.plausible?('+84 1900 5412345') # Premium, too long
+
 
 #### Zambia
     Phony.assert.plausible?('+260 75 027 3500') # Zamtel Mobile 075

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -590,7 +590,9 @@ describe 'plausibility' do
                                                                       '+598 805 123 45']
       it_is_correct_for 'Vietnam', :samples => ['+84 24 41234567',
                                                 '+84 28 41234567',
-                                                '+84 23 61234567']
+                                                '+84 23 61234567',
+                                                '+84 1900 1212',
+                                                '+84 1900 541234']
       it_is_correct_for 'Yemen', :samples => [['+967 1 234 567', '+967 1 234 5678'],
                                               '+967 7 234 567',
                                               '+967 77 123 4567',
@@ -617,16 +619,16 @@ describe 'plausibility' do
         Phony.plausible?('+62 22 0000 0000').should be_truthy
         Phony.plausible?('+62 22 000 000 000').should be_truthy
       end
-      
+
       it 'is correct for Italy' do
         Phony.plausible?('+39 0574 123').should be_falsy
         Phony.plausible?('+39 0574 1234').should be_truthy
         Phony.plausible?('+39 0574 12345').should be_falsy
-        
+
         Phony.plausible?('+39 085 541').should be_falsy
         Phony.plausible?('+39 085 5410').should be_truthy
         Phony.plausible?('+39 085 54105').should be_truthy
-        
+
         Phony.plausible?('+39 06 4991').should be_falsy
         Phony.plausible?('+39 06 49911').should be_truthy
         Phony.plausible?('+39 06 499112').should be_truthy

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -855,6 +855,8 @@ describe 'country descriptions' do
       it_splits '842841234567', ['84', '28', '4123', '4567'] # Ho Chi Minh City
       it_splits '84341234567', ['84', '34', '1234567'] # Viettel
       it_splits '84841234567', ['84', '84', '1234567'] # Vinaphone
+      it_splits '8419001212', ['84', '1900', '1212'] # Vinaphone
+      it_splits '841900541234', ['84', '1900', '541234'] # Vinaphone
     end
     describe 'Zambia' do
       it_splits '260211123456', ['260', '211', '123456']     # Fixed


### PR DESCRIPTION
Fixes #518 - 1900 premium rate numbers should be plausible for Vietnam

Source - [Wikipedia: Telephone numbers in Vietnam](https://en.wikipedia.org/wiki/Telephone_numbers_in_Vietnam#1900_number_allocation)


