### PR TITLE
Add a Japanese mobile number

### DIFF
--- a/lib/phony/countries/japan.rb
+++ b/lib/phony/countries/japan.rb
@@ -402,7 +402,7 @@ ndcs_with_5_subscriber_numbers = %w(
 Phony.define do
   country '81',
     trunk('0', normalize: true, format: true, split: true) |
-    one_of(%w(20 50 60 70 90))             >> split(4,4) | # mobile, VoIP telephony
+    one_of(%w(20 50 60 70 80 90))          >> split(4,4) | # mobile, VoIP telephony
     match(/\A(597)9[0178]\d+\z/)           >> split(2,4) |
     one_of(ndcs_with_5_subscriber_numbers) >> split(1,4) |
     match(/\A(4)70[019]\d+\z/)             >> split(4,4) |


### PR DESCRIPTION
## Changes
- Japanase mobile numbers often have the prefix "080". Therefore, I'm adding "80" to the mobile number.

### See
- https://en.wikipedia.org/wiki/Telephone_numbers_in_Japan