### PR TITLE
Fix Pakistani UAN handling

### DIFF
--- a/lib/phony/countries/pakistan.rb
+++ b/lib/phony/countries/pakistan.rb
@@ -112,7 +112,7 @@ Phony.define do
 
   country '92',
           one_of(ndcs_with_6_subscriber_numbers) >> split(3,3) |
-          one_of('122') >> split(3,3) | # universal access
+          one_of('111') >> split(3,3) | # universal access number
           one_of(ndcs_with_7_subscriber_numbers) >> split(4,3) |
           one_of(ndcs_with_8_subscriber_numbers) >> split(4,4) |
           one_of(%w(30 31 32 33 34 35 36)) >> split(4,4) | # mobile

--- a/qed/country-specific.md
+++ b/qed/country-specific.md
@@ -113,3 +113,11 @@ Error from issue #520.
 
     luxembourg.assert.plausible?('2634731')
     luxembourg.assert.plausible?('264412701')
+
+#### Pakistan
+
+Error from issue #527.
+
+    pakistan = Phony["92"]
+
+    pakistan.assert.plausible?('111332211')

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -618,6 +618,7 @@ describe 'country descriptions' do
       it_splits '92221234567', %w(92 22 1234 567)
       it_splits '92232123456', %w(92 232 123 456)
       it_splits '923012345678', %w(92 30 1234 5678)
+      it_splits '92111332211', %w(92 111 332 211)
     end
     describe 'Paraguay (Republic of)' do
       it_splits '59521123456', %w(595 21 123 456)


### PR DESCRIPTION
Fix for https://github.com/floere/phony/issues/527

Changes UAN prefix from `122` to `111` as per ITU (https://www.itu.int/dms_pub/itu-t/oth/02/02/T02020000A10002PDFE.pdf).