### PR TITLE
fix(527): full support for Pakistani UAN numbers

### DIFF
--- a/lib/phony/countries/pakistan.rb
+++ b/lib/phony/countries/pakistan.rb
@@ -3,7 +3,9 @@
 # Pakistan (Islamic Republic of)
 # https://www.numberingplans.com/?page=plans&sub=phonenr&alpha_2_input=PK
 
-ndcs_with_8_subscriber_numbers = %w[21 42 58]
+ndcs_mobile_plan = %w[30 31 32 33 34 35 36]
+
+ndcs_with_8_subscriber_numbers = %w[21 42]
 
 ndcs_with_7_subscriber_numbers = %w[
   22
@@ -106,14 +108,38 @@ ndcs_with_6_subscriber_numbers = %w[
   996
   997
   998
+  5811
+  5812
+  5813
+  5814
+  5815
+  5816
+  5817
+  5821
+  5822
+  5823
+  5824
+  5825
+  5826
+  2827
+  5828
 ]
 
 Phony.define do
   country '92',
-          one_of(ndcs_with_6_subscriber_numbers) >> split(3, 3) |
-          one_of('111') >> split(3, 3) | # universal access number
-          one_of(ndcs_with_7_subscriber_numbers) >> split(4, 3) |
-          one_of(ndcs_with_8_subscriber_numbers) >> split(4, 4) |
-          one_of(%w[30 31 32 33 34 35 36]) >> split(4, 4) | # mobile
+          one_of('111') >> split(3, 3) | # UAN without NDC |
+          one_of(ndcs_with_6_subscriber_numbers) >> matched_split(
+            /^(111)\d{6}$/ => [3, 3, 3], # UAN - always 6 digits
+            /^\d{6}$/ => [3, 3]
+          ) |
+          one_of(ndcs_with_7_subscriber_numbers) >> matched_split(
+            /^(111)\d{6}$/ => [3, 3, 3], # UAN - always 6 digits
+            /^\d{7}$/ => [4, 3]
+          ) |
+          one_of(ndcs_with_8_subscriber_numbers) >> matched_split(
+            /^(111)\d{6}$/ => [3, 3, 3], # UAN - always 6 digits
+            /^\d{8}$/ => [4, 4]
+          ) |
+          one_of(ndcs_mobile_plan) >> split(4, 4) | # mobile
           fixed(2) >> split(4, 4)
 end

--- a/qed/country-specific.md
+++ b/qed/country-specific.md
@@ -120,4 +120,13 @@ Error from issue #527.
 
     pakistan = Phony["92"]
 
+UAN - no NDC
     pakistan.assert.plausible?('111332211')
+UAN - 2 digits NDC / 7 digits NSN
+    pakistan.assert.plausible?('51111332211')
+UAN - 2 digits NDC / 8 digits NSN
+    pakistan.assert.plausible?('42111332211')    
+UAN - 3 digits NDC
+    pakistan.assert.plausible?('998111332211')
+UAN - 4 digits NDC
+    pakistan.assert.plausible?('5828111332211')

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -658,6 +658,10 @@ describe 'country descriptions' do
       it_splits '92232123456', %w[92 232 123 456]
       it_splits '923012345678', %w[92 30 1234 5678]
       it_splits '92111332211', %w[92 111 332 211]
+      it_splits '9251111332211', %w[92 51 111 332 211]
+      it_splits '9242111332211', %w[92 42 111 332 211]
+      it_splits '92998111332211', %w[92 998 111 332 211]
+      it_splits '925828111332211', %w[92 5828 111 332 211]
     end
 
     describe 'Paraguay (Republic of)' do


### PR DESCRIPTION
Realized that UANs with prefix (NDC) are still not supported. Updated list of NDCs with 6digits SNs by the way (ref: https://www.itu.int/dms_pub/itu-t/oth/02/02/T02020000A10002PDFE.pdf)