### PR TITLE
Update countries.rb

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -371,7 +371,7 @@ Phony.define do
 
   country '227', none >> split(4, 4) # Niger http://www.wtng.info/wtng-227-ne.html
   country '228', none >> split(4, 4) # Togolese Republic http://www.wtng.info/wtng-228-tg.html
-  country '229', none >> split(4, 4) # Benin http://www.itu.int/oth/T0202000017/en
+  country '229', none >> split(6, 4) # Benin http://www.itu.int/oth/T0202000017/en
 
   # Mauritius
   # http://www.wtng.info/wtng-230-mu.html

--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -371,7 +371,13 @@ Phony.define do
 
   country '227', none >> split(4, 4) # Niger http://www.wtng.info/wtng-227-ne.html
   country '228', none >> split(4, 4) # Togolese Republic http://www.wtng.info/wtng-228-tg.html
-  country '229', none >> split(6, 4) # Benin http://www.itu.int/oth/T0202000017/en
+
+  # Benin http://www.itu.int/oth/T0202000017/en
+  #
+  # There is no trunk code for this country and prefixes start with 0
+  country '229',
+          trunk('', normalize: false) |
+          none >> split(6, 4)
 
   # Mauritius
   # http://www.wtng.info/wtng-230-mu.html


### PR DESCRIPTION
Please see an update to https://www.itu.int/oth/T0202000017/en:

The Autorité de Régulation des Communications Electroniques et de la Poste (ARCEP-BENIN), Cotonou, announces, for 30 November 2024 at 0000 hours (UTC+1), the migration of the current national numbering plan of eight (8) digits in format ABPQMCDU to a new plan of ten (10) digits in format EZABPQMCDU. 

An update has been applied already that adds preceding digits to the NSN. 

This is currently causing validation failures for correct telephone numbers:

```
Phony.plausible?('+2290165111110', country_code: 'BJ')
=> false
```