### PR TITLE
adding support for leading 41 numbers in KW

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -1176,6 +1176,7 @@ Phony.define do
             /\A65816\d+\z/ => [4, 4, 4], # voicemail (mobile), Wataniya Telecom
             /\A1\d+\z/ => [3, 4], # geographic
             /\A2\d+\z/ => [4, 4], # geographic
+            /\A41\d+\z/ => [4, 4], # mobile (Virgin Mobile)
             /\A[569]\d+\z/ => [4, 4], # mobile
             /\A8\d+\z/ => [3, 3] # geographic
           )

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -308,7 +308,9 @@ describe 'plausibility' do
                                                                            '+850 2 381 2356',
                                                                            # '+850 2 8801 1234 5678 1256',
                                                                            '+850 191 123 4567']
-      it_is_correct_for 'Kuwait (State of)', samples: ['+965 2345 6789', '+965 181 2345']
+      it_is_correct_for 'Kuwait (State of)', samples: ['+965 2345 6789',
+                                                       '+965 181 2345',
+                                                       '+965 4123 4567']
       it_is_correct_for 'Kenya', samples: [
         '254201234567',
         '254111234567',

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -1143,6 +1143,7 @@ describe 'country descriptions' do
     describe 'Kuwait (State of)' do
       it_splits '96523456789', ['965', false, '2345', '6789']
       it_splits '9651812345', ['965', false, '181', '2345']
+      it_splits '96541234567', ['965', false, '4123', '4567']
     end
 
     describe "Lao People's Democratic Republic" do


### PR DESCRIPTION
https://www.citra.gov.kw/sites/en/LegalReferences/National_numbering_plan.pdf
https://en.wikipedia.org/wiki/Telephone_numbers_in_Kuwait

> Number 41 was allocated for [Virgin Mobile](https://en.wikipedia.org/wiki/Virgin_Mobile) numbers (year 2022)

As of 2022, phone numbers in Kuwait that begin with the digits "41" are now considered valid. 