### PR TITLE
Add 9 digit mobile numbers to Bosnia and Herzegovina definition

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -800,7 +800,14 @@ Phony.define do
           one_of('1', '2', '3', '4', '5', '7') >> split(3, 4) | # Ljubljana, Maribor, Celje, Kranj, Nova Gorica, Novo mesto
           fixed(3) >> split(2, 3) # catchall
 
-  country '387', trunk('0') | fixed(2) >> split(3, 3) # Bosnia and Herzegovina
+  # Bosnia and Herzegovina
+  country '387',
+          trunk('0') |
+          match(/^(60)(?:31|32|33|34|38|39)/) >> split(7) | # BH Mobile
+          match(/^(64)(?:40|41|42|43|44|45)/) >> split(7) | # Haloo
+          match(/^(67)(?:11|12)/) >> split(7) | # Novotel
+          fixed(2) >> split(3, 3) # catchall
+
   country '388', trunk('0') | fixed(2) >> split(3, 2, 2) # Group of countries, shared code
 
   # The Former Yugoslav Republic of Macedonia

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -46,7 +46,10 @@ describe 'plausibility' do
                                              '+43 463 12345'] # Klagenfurt
       it_is_correct_for 'Bosnia and Herzegovina', samples: ['+387 66 666 666',
                                                             '+387 37 123 456',
-                                                            '+387 33 222 111']
+                                                            '+387 33 222 111',
+                                                            '+387 60 3456789',
+                                                            '+387 64 4123456',
+                                                            '+387 67 1234567']
       it 'is correct for Brasil' do
         expect(Phony).to be_plausible('+55 67 998280912')
         expect(Phony).not_to be_plausible('+55 67 98280912')

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -142,6 +142,9 @@ describe 'country descriptions' do
     describe 'Bosnia and Herzegovina' do
       it_splits '38766666666', %w[387 66 666 666]
       it_splits '38733123456', %w[387 33 123 456]
+      it_splits '387603456789', %w[387 60 3456789]
+      it_splits '387644123456', %w[387 64 4123456]
+      it_splits '387671234567', %w[387 67 1234567]
     end
 
     describe 'Brazil' do


### PR DESCRIPTION
There are certain 9 digit numbers that are plausible, see:
https://en.wikipedia.org/wiki/Telephone_numbers_in_Bosnia_and_Herzegovina#Mobile_phone_codes

The basic catch-all mechanism should work for all other mobile numbers as well as those are just 8 digits in length.
However, BH Mobile, Haloo, and Novotel have number blocks that have a minimum length of 9, so some valid numbers are currently failing the phony plausibility check.