### PR TITLE
Add 55 mobile code for Vietnam

### DIFF
--- a/lib/phony/countries/vietnam.rb
+++ b/lib/phony/countries/vietnam.rb
@@ -90,6 +90,7 @@ mobile = [
   '38', # Viettel Mobile
   '39', # Viettel Mobile
   '52', # Vietnammobile
+  '55', # Wintel (previously known as Reddi)
   '56', # Vietnamobile
   '58', # Vietnamobile (previously known as HT Mobile)
   '59', # GTel (traded as Beeline)

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -602,6 +602,11 @@ describe 'plausibility' do
                                              '+84 23 61234567',
                                              '+84 1900 1212',
                                              '+84 1900 541234']
+
+      it 'is correct for 55 Vietnam mobile code' do
+        expect(Phony).to be_plausible('+84 55 9905599') # Wintel (Previously Reddi)
+      end
+
       it_is_correct_for 'Yemen', samples: [['+967 1 234 567', '+967 1 234 5678'],
                                            '+967 7 234 567',
                                            '+967 77 123 4567',


### PR DESCRIPTION
We have a customer wishing to create a record for +84 55 9905599

`.plausible?` returns `false` for the above number.

I have tested against a branch where `spec/functional/plausibility_spec.rb` passes when '55' is added to https://github.com/floere/phony/blob/master/lib/phony/countries/vietnam.rb#L83

```
it 'is correct for 55 Vietnam mobile code' do
  expect(Phony).to be_plausible('+84 55 9905599') # Wintel (Previously Reddi)
end
```
Test added like so, instead of

```
it_is_correct_for 'Vietnam', samples: [
       '+84 24 4123 4567',
       '+84 55 9905599',
       '+84 28 41234567',
       '+84 23 61234567',
       '+84 1900 1212',
       '+84 1900 541234']
```

to prevent:
```
 "It should not validate #{value}, but does."
       It should not validate +84 55 9905599, but does.
```