### PR TITLE
Add toll-free 1800 number support for Colombia and Ecuador

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -229,6 +229,7 @@ Phony.define do
   # Colombia.
   # http://www.itu.int/oth/T020200002C/en
   country '57',
+          match(/\A(1800)\d+\z/) >> split(3, 4) | # toll free 1800 numbers
           match(/\A(3\d\d)\d+\z/) >> split(3, 4) | # mobile (300 310 311 312 313 315 316)
           match(/\A(60\d)\d+\z/) >> split(3, 4) |
           fixed(1) >> split(3, 4)
@@ -899,6 +900,7 @@ Phony.define do
   # https://www.numberingplans.com/?page=plans&sub=phonenr&alpha_2_input=EC&current_page=1
   # https://en.wikipedia.org/wiki/Telephone_numbers_in_Ecuador
   country '593',
+          match(/\A(1800)\d+\z/) >> split(3, 3) | # toll free 1800 numbers
           one_of('9') >> split(4, 4) |
           match(/\A([\d]{2})\d{7}\z/) >> split(3, 4) |
           fixed(1) >> split(3, 4)

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -188,14 +188,16 @@ describe 'plausibility' do
         expect(Phony).to be_plausible('+359 999 123456')
       end
 
-      it_is_correct_for 'Colombia', samples: ['+57 601 411 1899',
+      it_is_correct_for 'Colombia', samples: ['+57 300 111 2222',
+                                              '+57 601 411 1899',
                                               '+57 602 111 2222',
                                               '+57 603 111 2222',
                                               '+57 604 111 2222',
                                               '+57 605 111 2222',
                                               '+57 606 111 2222',
                                               '+57 607 111 2222',
-                                              '+57 608 111 2222']
+                                              '+57 608 111 2222',
+                                              '+57 1800 111 2222']
       it_is_correct_for 'Congo', samples: '+242 1234 56789'
       it_is_correct_for 'Cook Islands', samples: '+682  71928'
       it_is_correct_for 'Costa Rica', samples: '+506 2 234 5678'
@@ -240,6 +242,7 @@ describe 'plausibility' do
         expect(Phony).to be_plausible('+593 7 400 0000')
         expect(Phony).to be_plausible('+593 7 600 0000')
         expect(Phony).to be_plausible('+593 9 0000 0000') # mobile
+        expect(Phony).to be_plausible('+593 1800 000 000') # toll free
       end
 
       it_is_correct_for 'Equatorial Guinea', samples: ['+240 222 201 123',


### PR DESCRIPTION
This PR addresses this issue: https://github.com/floere/phony/issues/553

Add toll-free 1800 number support for Colombia and Ecuador

## Changes
- Added regex pattern for Colombian 1800 numbers with split(3,4) 
- Added regex pattern for Ecuadorian 1800 numbers with split(3,3)
- Added test cases for both countries

For the Colombian phone numbers, I checked the format here: https://www.unitedworldtelecom.com/services/toll-free-numbers/colombia-toll-free-numbers/ , it's `+57 1800 XXX XXXX`.

For Ecuadorian toll-free numbers, I checked the format here: https://zadarma.com/en/tariffs/numbers/ecuador/toll-free/, it's `+593 1800 XXX XXX`.

## Testing
- All existing tests pass (126 examples)
- New numbers validate correctly:
  - `+57 1800 111 2222` (Colombia)
  - `+593 1800 000 000` (Ecuador)