### PR TITLE
Update Brazil definition to include toll free 800 numbers

### DIFF
--- a/lib/phony/countries/brazil.rb
+++ b/lib/phony/countries/brazil.rb
@@ -93,14 +93,14 @@ ndcs = '(11|12|13|14|15|16|17|18|19|21|22|24|27|28|31|32|33|34|35|36|37|38|41|42
 
 service = %w[100 128 190 191 192 193 194 197 198 199] # State specific numbers were not added. See http://www.brasil.gov.br/navegue_por/aplicativos/agenda
 
-special_numbers_3_4 = %w[0800]
+toll_free = %w[800 0800]
 special_numbers_4 = %w[3003 4003 4004 4020]
 
 Phony.define do
   country '55',
           match(/^#{ndcs}9\d{8}$/)     >> split(5, 4) |
           match(/^#{ndcs}[2-5]\d{7}$/) >> split(4, 4) |
-          one_of(special_numbers_3_4)  >> split(3, 4) |
+          one_of(toll_free)            >> split(3, 4) |
           one_of(special_numbers_4)    >> split(4) |
           one_of(service)              >> split(3) |
           fixed(3)                     >> split(3)

--- a/qed/plausibility.md
+++ b/qed/plausibility.md
@@ -245,6 +245,11 @@ NDC with several subscriber number length.
       '+267 8 1234 567'
     ]
 
+#### Brazil
+
+    plausible? true: '+55 0800 123 4567'
+    plausible? true: '+55 800 123 4567'
+
 #### Brunei
 
     plausible? true: '+673 5 523 876'

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -50,13 +50,15 @@ describe 'plausibility' do
                                                             '+387 60 3456789',
                                                             '+387 64 4123456',
                                                             '+387 67 1234567']
-      it 'is correct for Brasil' do
+      it 'is correct for Brazil' do
         expect(Phony).to be_plausible('+55 67 998280912')
         expect(Phony).not_to be_plausible('+55 67 98280912')
         expect(Phony).not_to be_plausible('+55 11 12345678')
         expect(Phony).not_to be_plausible('+55 11 123456789')
         expect(Phony).not_to be_plausible('+55 11 023456789')
         expect(Phony).to be_plausible('+55 11 22345678')
+        expect(Phony).to be_plausible('+55 0800 123 4567')
+        expect(Phony).to be_plausible('+55 800 123 4567')
       end
 
       it 'is correct for Bulgaria' do

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -179,6 +179,7 @@ describe 'country descriptions' do
 
       context 'with special numbers' do
         it_splits '5508002221234', %w[55 0800 222 1234]
+        it_splits '558002221234', %w[55 800 222 1234]
         it_splits '5530032221', %w[55 3003 2221]
         it_splits '5540209999', %w[55 4020 9999]
         it_splits '5540038999', %w[55 4003 8999]


### PR DESCRIPTION
Fixes #564 - Fix plausibility for Brazilian `800` toll free numbers